### PR TITLE
Adding IRSA S3 download to notebook

### DIFF
--- a/forced_photometry/multiband_photometry.ipynb
+++ b/forced_photometry/multiband_photometry.ipynb
@@ -167,6 +167,115 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Pull image datasets from the cloud"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Use the fornax cloud access API to obtain the IRAC data from the IRSA S3 bucket. \n",
+    "\n",
+    "Details here may change as the prototype code is being added to the appropriate libraries, as well as the data holding to the appropriate NGAP storage as opposed to IRSA resources."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Temporary solution\n",
+    "# This relies on the assumption that https://github.com/fornax-navo/fornax-cloud-access-API is being cloned to this environment. \n",
+    "# If it's not, then run a ``git clone https://github.com/fornax-navo/fornax-cloud-access-API --depth=1`` from a terminal at the highest directory root.\n",
+    "\n",
+    "# Until https://github.com/fornax-navo/fornax-cloud-access-API/pull/4 is merged clone the fork instead:\n",
+    "# ``git clone https://github.com/bsipocz/fornax-cloud-access-API --depth=1 -b handler_return``\n",
+    "\n",
+    "sys.path.append('../../fornax-cloud-access-API')\n",
+    "\n",
+    "import pyvo\n",
+    "import fornax"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Getting the COSMOS address from the registry to follow PyVO user case approach. We could hardwire it.\n",
+    "image_services = pyvo.regsearch(servicetype='image')\n",
+    "irsa_cosmos = [s for s in image_services if 'irsa' in s.ivoid and 'cosmos' in s.ivoid][0]\n",
+    "\n",
+    "# The search returns 11191 entries, but unfortunately we cannot really filter efficiently in the query\n",
+    "# itself (https://irsa.ipac.caltech.edu/applications/Atlas/AtlasProgramInterface.html#inputparam)\n",
+    "# to get only the Spitzer IRAC results from COSMOS as a mission. We will do the filtering in a next step before download.\n",
+    "cosmos_results = irsa_cosmos.search(coords).to_table()\n",
+    "\n",
+    "spitzer = cosmos_results[cosmos_results['dataset'] == 'IRAC']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Temporarily add the cloud_access metadata to the Atlas response. \n",
+    "\n",
+    "fname = spitzer['fname']\n",
+    "spitzer['cloud_access'] = [(f'{{\"aws\": {{ \"bucket\": \"irsa-mast-tike-spitzer-data\",'\n",
+    "                            f'             \"region\": \"us-east-1\",'\n",
+    "                            f'             \"access\": \"open\",'\n",
+    "                            f'             \"path\": \"data/COSMOS/{fn}\" }} }}') for fn in fname]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Adding function to download multiple files using the fornax API. \n",
+    "# Requires https://github.com/fornax-navo/fornax-cloud-access-API/pull/4\n",
+    "def fornax_download(data_table, data_directory='../data', access_url_column='access_url',\n",
+    "                    fname_filter=None, verbose=False):\n",
+    "    working_dir = os.getcwd()\n",
+    "    \n",
+    "    os.chdir(data_directory)\n",
+    "    for row in data_table:\n",
+    "        if fname_filter is not None and fname_filter not in row['fname']:\n",
+    "            continue\n",
+    "        handler = fornax.get_data_product(row, 'aws', access_url_column=access_url_column, verbose=verbose)\n",
+    "        handler.download()\n",
+    "        \n",
+    "    os.chdir(working_dir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    }
+   },
+   "outputs": [],
+   "source": [
+    "fornax_download(spitzer, access_url_column='sia_url', fname_filter='go2_sci', verbose=True)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/forced_photometry/multiband_photometry.ipynb
+++ b/forced_photometry/multiband_photometry.ipynb
@@ -264,7 +264,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fornax_download(spitzer, access_url_column='sia_url', fname_filter='go2_sci', verbose=True)"
+    "fornax_download(spitzer, access_url_column='sia_url', fname_filter='go2_sci', \n",
+    "                data_directory='../data/IRAC', verbose=True)"
    ]
   },
   {

--- a/forced_photometry/multiband_photometry.ipynb
+++ b/forced_photometry/multiband_photometry.ipynb
@@ -150,12 +150,12 @@
     "#what is the central RA and DEC of the desired catalog\n",
     "coords = SkyCoord('150.01d 2.2d', frame='icrs')  #COSMOS center acording to Simbad\n",
     "\n",
-    "#how large is the search radius\n",
-    "rad_in_arcmin = 15#full COSMOS is 48arcmin  #was testing with smaller like 3 or 15\n",
+    "#how large is the search radius, in arcmin\n",
+    "radius = 15 * u.arcmin #full COSMOS is 48arcmin  #was testing with smaller like 3 or 15\n",
     "\n",
     "#use Astroquery to get the catalog\n",
     "#specify only select columns to limit the size of the catalog\n",
-    "cosmos_table = Irsa.query_region(coords, catalog = \"cosmos2015\",  radius = rad_in_arcmin*u.arcmin, \n",
+    "cosmos_table = Irsa.query_region(coords, catalog=\"cosmos2015\", radius=radius, \n",
     "                                 selcols='ra,dec,id,Ks_FLUX_APER2,Ks_FLUXERR_APER2, PHOTOZ, SPLASH_1_MAG,SPLASH_1_MAGERR, SPLASH_1_FLUX,SPLASH_1_FLUX_ERR,SPLASH_2_FLUX, SPLASH_2_FLUX_ERR,SPLASH_3_FLUX,SPLASH_3_FLUX_ERR,SPLASH_4_FLUX, SPLASH_4_FLUX_ERR, FLUX_GALEX_NUV,FLUX_GALEX_FUV,FLUX_CHANDRA_05_2,FLUX_CHANDRA_2_10, FLUX_CHANDRA_05_10,ID_CHANDRA09 , type,r_MAG_AUTO,r_MAGERR_AUTO, FLUX_24, FLUXERR_24, MAG_GALEX_NUV, MAGERR_GALEX_NUV,MAG_GALEX_FUV, MAGERR_GALEX_FUV')\n",
     "\n",
     "#select those rows with either chandra fluxes or Galex NUV fluxes\n",
@@ -185,9 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Temporary solution\n",
@@ -206,9 +204,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Getting the COSMOS address from the registry to follow PyVO user case approach. We could hardwire it.\n",
@@ -226,26 +222,24 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Temporarily add the cloud_access metadata to the Atlas response. \n",
+    "# This dataset has limited acces, thus 'region' should be used instead of 'open'.\n",
+    "# S3 access should be available from the daskhub and those who has their IRSA token set up.\n",
     "\n",
     "fname = spitzer['fname']\n",
     "spitzer['cloud_access'] = [(f'{{\"aws\": {{ \"bucket\": \"irsa-mast-tike-spitzer-data\",'\n",
     "                            f'             \"region\": \"us-east-1\",'\n",
-    "                            f'             \"access\": \"open\",'\n",
+    "                            f'             \"access\": \"region\",'\n",
     "                            f'             \"path\": \"data/COSMOS/{fn}\" }} }}') for fn in fname]\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Adding function to download multiple files using the fornax API. \n",
@@ -267,12 +261,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fornax_download(spitzer, access_url_column='sia_url', fname_filter='go2_sci', verbose=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Use astroquery.mast to obtain Galex from the MAST archive"
    ]
   },
   {


### PR DESCRIPTION
The functionality requires https://github.com/fornax-navo/fornax-cloud-access-API/pull/4 to be merged, therefore temporary instructions for cloning the branch from the fork are included.


S3 data download works for me locally using my IRSA AWS token, and also works on daskhub. However there are some issues with falling back on the on-prem download for all other cases, it may be either a user bug in the notebook or a bug in the fornax API code.

@troyraen - Unfortunately atm we have download functionality, but not open, so kept the logic of dumping the data in the `../data` path.