### PR TITLE
Extract background cutouts from `bkg_hdus` instead of `hdulists`

### DIFF
--- a/forced_photometry/multiband_photometry.ipynb
+++ b/forced_photometry/multiband_photometry.ipynb
@@ -640,7 +640,7 @@
     "    subimage, nodata_param, x1, y1, subimage_wcs = extract_cutout(ra, dec,cutout_width, mosaic_pix_scale, hdulists[g_band], wcs_infos[g_band])\n",
     "    #for the Galex images, also need to make a background cutout image\n",
     "    if background_method == 'skybg':\n",
-    "        bgsubimage, bgnodata_param, bgx1, bgy1, bgimage_wcs = extract_cutout(ra, dec,cutout_width, mosaic_pix_scale, hdulists[g_band], wcs_infos[g_band])\n",
+    "        bgsubimage, bgnodata_param, bgx1, bgy1, bgimage_wcs = extract_cutout(ra, dec,cutout_width, mosaic_pix_scale, bkg_hdus[g_band], wcs_infos[g_band])\n",
     "    \n",
     "    \n",
     "    #catch errors in making the cutouts\n",

--- a/forced_photometry/multiband_photometry.ipynb
+++ b/forced_photometry/multiband_photometry.ipynb
@@ -539,7 +539,8 @@
     "bkg_hdus = [fits.open(skybgfile)[0] for skybgfile in skybgfiles]\n",
     "\n",
     "#grab the WCS of the mosaics\n",
-    "wcs_infos = [WCS(hdulist) for hdulist in hdulists]"
+    "wcs_infos = [WCS(hdulist) for hdulist in hdulists]\n",
+    "bkg_wcs_infos = [WCS(bkg_hdu) for bkg_hdu in bkg_hdus]"
    ]
   },
   {
@@ -640,7 +641,7 @@
     "    subimage, nodata_param, x1, y1, subimage_wcs = extract_cutout(ra, dec,cutout_width, mosaic_pix_scale, hdulists[g_band], wcs_infos[g_band])\n",
     "    #for the Galex images, also need to make a background cutout image\n",
     "    if background_method == 'skybg':\n",
-    "        bgsubimage, bgnodata_param, bgx1, bgy1, bgimage_wcs = extract_cutout(ra, dec,cutout_width, mosaic_pix_scale, bkg_hdus[g_band], wcs_infos[g_band])\n",
+    "        bgsubimage, bgnodata_param, bgx1, bgy1, bgimage_wcs = extract_cutout(ra, dec,cutout_width, mosaic_pix_scale, bkg_hdus[g_band], bkg_wcs_infos[g_band])\n",
     "    \n",
     "    \n",
     "    #catch errors in making the cutouts\n",


### PR DESCRIPTION
@bsipocz @jkrick (not sure who wants to be tagged here)

This PR includes a single change to fix what appears to be a bug in the cutout creation. The bug is that the calls to create the objects `subimage` and `bgsubimage` were identical. I'm guessing that `bgsubimage` is supposed be created from the sky background files in `bkg_hdus` -- this is the change made in this PR.

If this is not actually a bug, or is not the right fix, I will close this.
