### PR TITLE
MAINT: Several changes to iron out bugs and improve UX

### DIFF
--- a/code/cutout.py
+++ b/code/cutout.py
@@ -93,10 +93,9 @@ def extract(ra, dec, *, hdu, cutout_width, mosaic_pix_scale):
     size = int(math.ceil(size))  # round up the nearest integer
 
     # make the cutout
-    cutout = Cutout2D(hdu.data, position, size,
-                      copy=True, mode="trim", wcs=wcs_info)
-    subimage = cutout.data.copy()
-    subimage_wcs = cutout.wcs.copy()
+    cutout = Cutout2D(hdu.data, position, size, mode="trim", wcs=wcs_info)
+    subimage = cutout.data
+    subimage_wcs = cutout.wcs
 
     # now need to set the values of x1, y1 at the location of the target *in the cutout*
     x1, y1 = subimage_wcs.all_world2pix(ra, dec, 1)

--- a/forced_photometry/multiband_photometry.ipynb
+++ b/forced_photometry/multiband_photometry.ipynb
@@ -814,6 +814,8 @@
     "#Here is where the multiprocessing work gets done\n",
     "t2 = time.time()\n",
     "outputs = []\n",
+    "# number of processes can be controlled with a max_workers arg in ProcessPoolExecutor\n",
+    "# defaults to the number of available processors, beyond which no performance gains are seen\n",
     "with concurrent.futures.ProcessPoolExecutor() as executor:\n",
     "    for result in executor.map(calculate_flux, paramlist):\n",
     "        # print(result)\n",

--- a/forced_photometry/multiband_photometry.ipynb
+++ b/forced_photometry/multiband_photometry.ipynb
@@ -147,7 +147,7 @@
     "coords = SkyCoord('150.01d 2.2d', frame='icrs')  #COSMOS center acording to Simbad\n",
     "\n",
     "#how large is the search radius, in arcmin\n",
-    "radius = 15 * u.arcmin #full COSMOS is 48arcmin  #was testing with smaller like 3 or 15\n",
+    "radius = 1 * u.arcmin #full COSMOS is 48arcmin  #was testing with smaller like 3 or 15\n",
     "\n",
     "#use Astroquery to get the catalog\n",
     "#specify only select columns to limit the size of the catalog\n",

--- a/forced_photometry/multiband_photometry.ipynb
+++ b/forced_photometry/multiband_photometry.ipynb
@@ -866,7 +866,7 @@
     "#Here is where the multiprocessing work gets done\n",
     "t2 = time.time()\n",
     "outputs = []\n",
-    "with concurrent.futures.ProcessPoolExecutor(24) as executor:\n",
+    "with concurrent.futures.ProcessPoolExecutor() as executor:\n",
     "    for result in executor.map(calculate_flux, paramlist):\n",
     "        # print(result)\n",
     "        df.loc[result[0],\n",

--- a/forced_photometry/multiband_photometry.ipynb
+++ b/forced_photometry/multiband_photometry.ipynb
@@ -602,9 +602,6 @@
     "    ('../data/Galex/COSMOS_04-fd-int.fits.gz', '../data/Galex/COSMOS_04-fd-skybg.fits.gz'),\n",
     "]\n",
     "\n",
-    "# load the primary HDUs\n",
-    "hdu_pairs = [tuple(fits.open(fin)[0] for fin in pair) for pair in sci_bkg_pairs]\n",
-    "\n",
     "# the input file pairs are not necessarily one-to-one with the bands, \n",
     "# so we'll write a function to look up the correct pair\n",
     "def lookup_img_pair(img_pairs, band_idx, galex_image=None):\n",
@@ -774,7 +771,7 @@
     "paramlist = []\n",
     "for row in df.itertuples():\n",
     "    for band in all_bands:\n",
-    "        img_pair = lookup_img_pair(hdu_pairs, band.idx, row.galex_image)  # pre-loaded HDUs\n",
+    "        img_pair = lookup_img_pair(sci_bkg_pairs, band.idx, row.galex_image)  # file paths only\n",
     "        paramlist.append(\n",
     "            [row.Index, band, row.ra, row.dec, row.type, row.ks_flux_aper2, img_pair, df]\n",
     "        )            "

--- a/forced_photometry/multiband_photometry.ipynb
+++ b/forced_photometry/multiband_photometry.ipynb
@@ -147,7 +147,7 @@
     "coords = SkyCoord('150.01d 2.2d', frame='icrs')  #COSMOS center acording to Simbad\n",
     "\n",
     "#how large is the search radius, in arcmin\n",
-    "radius = 1 * u.arcmin #full COSMOS is 48arcmin  #was testing with smaller like 3 or 15\n",
+    "radius = 1 * u.arcmin #full COSMOS is 48arcmin\n",
     "\n",
     "#use Astroquery to get the catalog\n",
     "#specify only select columns to limit the size of the catalog\n",

--- a/forced_photometry/multiband_photometry.ipynb
+++ b/forced_photometry/multiband_photometry.ipynb
@@ -626,55 +626,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### A little Data Exploration"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#Use IRSA's firefly to display image and overlay table\n",
-    "#just so we know what the data looks like\n",
-    "fc = FireflyClient.make_client()\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#give firefly one of the mosaics we are using here\n",
-    "imval = fc.upload_file(sci_bkg_pairs[0][0])\n",
-    "status = fc.show_fits(file_on_server=imval, plot_id=\"IRAC_ch1\", title='IRAC ch1')\n",
-    "\n",
-    "#and give firefly a table\n",
-    "#first convert to fits table from pandas\n",
-    "t_df = Table.from_pandas(df)\n",
-    "tablename = '../data/IRAC/COSMOS_table.fits'\n",
-    "t_df.write(tablename, overwrite = \"True\")\n",
-    "file= fc.upload_file(tablename)\n",
-    "status = fc.show_table(file, tbl_id='df', title='COSMOS catalog')\n",
-    "\n",
-    "#this should work, and is simpler, but isn't working.\n",
-    "#file_table = ffplt.upload_table(t_df, title = 'COSMOS catalog')\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Note: \n",
-    "This view will not display all of the catalog rows overlaid on the image.  To do that, narrow down the catalog size by filtering on the catalog inside of the IRSA Viewer web browser.  Documentation for how to interacto with IRSA Viewer is here: https://irsa.ipac.caltech.edu/onlinehelp/irsaviewer/"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Main Function to do the forced photometry"
    ]
   },


### PR DESCRIPTION
Closes #46 

- remove `max_workers` arg in `concurrent.futures.ProcessPoolExecutor`. This now defaults to the number of available processors.
- remove `firefly`
- remove superfluous `copy` calls
- change initial search radius 15 arcmin -> 1 arcmin
- load images on demand. This now sends only file paths into `calc_instrflux` and leaves all data loading to `cutout.extract`. In a test of 100 sources, this is considerably _faster_ than loading all the data up front (approx. 1min vs 2min). My naive guess is that the latter is only slower because of the overhead required to copy all of the pre-loaded data into each child process. If that's true, the latter might still be faster for a larger number of sources.

cc: @bsipocz @jkrick 