### PR TITLE
Make `code` modules safe for parallelization

### DIFF
--- a/light_curves/code/HCV_functions.py
+++ b/light_curves/code/HCV_functions.py
@@ -186,8 +186,8 @@ def HCV_get_lightcurves(coords_list, labels_list, radius):
     for ccount, coord in enumerate(coords_list):
 
         #doesn't take SkyCoord, convert to floats
-        ra = coords_list.ra.deg[ccount]
-        dec = coords_list.dec.deg[ccount]
+        ra = coord.ra.deg
+        dec = coord.dec.deg
         lab = labels_list[ccount]
 
         #IC 1613 from the demo for testing

--- a/light_curves/code/HCV_functions.py
+++ b/light_curves/code/HCV_functions.py
@@ -4,6 +4,10 @@ from tqdm import tqdm
 import pandas as pd
 from astropy.coordinates import SkyCoord
 
+from .fluxconversions import convertACSmagtoflux
+from .data_structures import MultiIndexDFObject
+
+
 ## Functions related to the HCV.
 def get_hscapiurl():
     """
@@ -160,13 +164,11 @@ def checklegal_hcv(table,release,magtype):
             raise ValueError("Bad value for magtype (must be one of {})".format(
                 ", ".join(magtypelist)))
             
-def HCV_get_lightcurves(df_lc, coords_list, labels_list, radius):
+def HCV_get_lightcurves(coords_list, labels_list, radius):
     """Searches Hubble Catalog of variables for light curves from a list of input coordinates
     
     Parameters
     ----------
-    df_lc : pandas multiindex dataframe
-        the main data structure to store all light curves
     coords_list : list of astropy skycoords
         the coordinates of the targets for which a user wants light curves
     labels_list: list of strings
@@ -180,6 +182,7 @@ def HCV_get_lightcurves(df_lc, coords_list, labels_list, radius):
         the main data structure to store all light curves
     """
 
+    df_lc = MultiIndexDFObject()
     for ccount, coord in enumerate(coords_list):
 
         #doesn't take SkyCoord, convert to floats

--- a/light_curves/code/HCV_functions.py
+++ b/light_curves/code/HCV_functions.py
@@ -4,8 +4,8 @@ from tqdm import tqdm
 import pandas as pd
 from astropy.coordinates import SkyCoord
 
-from .fluxconversions import convertACSmagtoflux
-from .data_structures import MultiIndexDFObject
+from fluxconversions import convertACSmagtoflux
+from data_structures import MultiIndexDFObject
 
 
 ## Functions related to the HCV.

--- a/light_curves/code/TESS_Kepler_functions.py
+++ b/light_curves/code/TESS_Kepler_functions.py
@@ -3,13 +3,15 @@ import pandas as pd
 from astropy.coordinates import SkyCoord
 import lightkurve as lk
 
-def TESS_Kepler_get_lightcurves(df_lc, coords_list, labels_list, radius):
+from .clean_filternames import clean_filternames
+from .data_structures import MultiIndexDFObject
+
+
+def TESS_Kepler_get_lightcurves(coords_list, labels_list, radius):
     """Searches TESS, Kepler, and K2 for light curves from a list of input coordinates
     
     Parameters
     ----------
-    df_lc : pandas multiindex dataframe
-        the main data structure to store all light curves
     coords_list : list of astropy skycoords
         the coordinates of the targets for which a user wants light curves
     labels_list: list of strings
@@ -23,8 +25,7 @@ def TESS_Kepler_get_lightcurves(df_lc, coords_list, labels_list, radius):
         the main data structure to store all light curves
     """
     
-        
-    
+    df_lc = MultiIndexDFObject()
     #for all objects
     for ccount, coord in enumerate(tqdm(coords_list)):
     #for testing, this has 79 light curves between the three missions.

--- a/light_curves/code/TESS_Kepler_functions.py
+++ b/light_curves/code/TESS_Kepler_functions.py
@@ -3,8 +3,8 @@ import pandas as pd
 from astropy.coordinates import SkyCoord
 import lightkurve as lk
 
-from .clean_filternames import clean_filternames
-from .data_structures import MultiIndexDFObject
+from clean_filternames import clean_filternames
+from data_structures import MultiIndexDFObject
 
 
 def TESS_Kepler_get_lightcurves(coords_list, labels_list, radius):

--- a/light_curves/code/WISE_functions.py
+++ b/light_curves/code/WISE_functions.py
@@ -38,8 +38,8 @@ def WISE_get_lightcurves(coords_list, labels_list, radius, bandlist):
     #for ccount in range(1):#enumerate(coords_list):
     for ccount, coord in enumerate(tqdm(coords_list)):
         #doesn't take SkyCoord, convert to floats
-        ra = coords_list.ra.deg[ccount]
-        dec = coords_list.dec.deg[ccount]
+        ra = coord.ra.deg 
+        dec = coord.dec.deg 
         lab = labels_list[ccount]
         try:
             #search the untimely catalog

--- a/light_curves/code/WISE_functions.py
+++ b/light_curves/code/WISE_functions.py
@@ -4,8 +4,8 @@ from astropy.coordinates import SkyCoord
 from unTimely_Catalog_tools import unTimelyCatalogExplorer
 import os
 
-from .data_structures import MultiIndexDFObject
-from .fluxconversions import convert_WISEtoJanskies
+from data_structures import MultiIndexDFObject
+from fluxconversions import convert_WISEtoJanskies
 
 
 #WISE

--- a/light_curves/code/WISE_functions.py
+++ b/light_curves/code/WISE_functions.py
@@ -4,14 +4,16 @@ from astropy.coordinates import SkyCoord
 from unTimely_Catalog_tools import unTimelyCatalogExplorer
 import os
 
+from .data_structures import MultiIndexDFObject
+from .fluxconversions import convert_WISEtoJanskies
+
+
 #WISE
-def WISE_get_lightcurves(df_lc, coords_list, labels_list, radius, bandlist):
+def WISE_get_lightcurves(coords_list, labels_list, radius, bandlist):
     """Searches WISE catalog from meisner et al., 2023 for light curves from a list of input coordinates
     
     Parameters
     ----------
-    df_lc : pandas multiindex dataframe
-        the main data structure to store all light curves
     coords_list : list of astropy skycoords
         the coordinates of the targets for which a user wants light curves
     labels_list: list of strings
@@ -32,6 +34,7 @@ def WISE_get_lightcurves(df_lc, coords_list, labels_list, radius, bandlist):
                                   catalog_base_url='http://unwise.me/data/neo7/untimely-catalog/',
                                   catalog_index_file='untimely_index-neo7.fits')
 
+    df_lc = MultiIndexDFObject()
     #for ccount in range(1):#enumerate(coords_list):
     for ccount, coord in enumerate(tqdm(coords_list)):
         #doesn't take SkyCoord, convert to floats

--- a/light_curves/code/gaia_functions.py
+++ b/light_curves/code/gaia_functions.py
@@ -11,7 +11,7 @@ from astroquery.gaia import Gaia
 
 import matplotlib.pyplot as plt
 
-from .data_structures import MultiIndexDFObject
+from data_structures import MultiIndexDFObject
 
 
 def Gaia_get_lightcurve(coords_list, labels_list, object_names , verbose):

--- a/light_curves/code/gaia_functions.py
+++ b/light_curves/code/gaia_functions.py
@@ -11,18 +11,16 @@ from astroquery.gaia import Gaia
 
 import matplotlib.pyplot as plt
 
+from .data_structures import MultiIndexDFObject
 
-def Gaia_get_lightcurve(df_lc , coords_list, labels_list, object_names , verbose):
+
+def Gaia_get_lightcurve(coords_list, labels_list, object_names , verbose):
     '''
     Creates a lightcurve Pandas MultiIndex object from Gaia data for a list of coordinates.
     This is the MAIN function.
     
     Parameters
     ----------
-    df_lc : Lightcurve Pandas MultiIndex object
-        Lightcurve object to which to append the Gaia lightcurve. Must be created beforehand,
-        but can be an empty object.
-    
     coords_list : list of Astropy SkyCoord objects
         List of coordinates of the sources
     
@@ -44,7 +42,7 @@ def Gaia_get_lightcurve(df_lc , coords_list, labels_list, object_names , verbose
     of Gaia observations.
     
     '''
-    
+
     ## Retrieve Gaia table with Source IDs and photometry ==============
     gaia_table = Gaia_retrieve_median_photometry(coords_list , labels_list, object_names,
                                          gaia_source_table="gaiaedr3.gaia_source", # Which Table to use
@@ -75,7 +73,7 @@ def Gaia_get_lightcurve(df_lc , coords_list, labels_list, object_names , verbose
                                     gaia_epoch_phot=gaia_epoch_phot ,
                                     verbose = verbose)
 
-    ## Append to existing MultiIndex object that is provided to this function
+    df_lc = MultiIndexDFObject()
     df_lc.append(df_lc_gaia)
     
     

--- a/light_curves/code/heasarc_functions.py
+++ b/light_curves/code/heasarc_functions.py
@@ -3,7 +3,7 @@ import pandas as pd
 from astropy.coordinates import SkyCoord
 from astroquery.heasarc import Heasarc
 
-from .data_structures import MultiIndexDFObject
+from data_structures import MultiIndexDFObject
 
 
 def HEASARC_get_lightcurves(coords_list,labels_list,radius, mission_list ):

--- a/light_curves/code/heasarc_functions.py
+++ b/light_curves/code/heasarc_functions.py
@@ -3,16 +3,18 @@ import pandas as pd
 from astropy.coordinates import SkyCoord
 from astroquery.heasarc import Heasarc
 
+from .data_structures import MultiIndexDFObject
 
-def HEASARC_get_lightcurves(df_lc, coords_list,radius, mission_list ):
+
+def HEASARC_get_lightcurves(coords_list,labels_list,radius, mission_list ):
     """Searches HEASARC archive for light curves from a specific list of mission catalogs
     
     Parameters
     ----------
-    df_lc : pandas multiindex dataframe
-        the main data structure to store all light curves
     coords_list : list of astropy skycoords
         the coordinates of the targets for which a user wants light curves
+    labels_list: list of strings
+        journal articles associated with the target coordinates
     radius : astropy.units.quantity.Quantity
         search radius, how far from the source should the archives return results
     mission_list : str list
@@ -32,6 +34,7 @@ def HEASARC_get_lightcurves(df_lc, coords_list,radius, mission_list ):
         #to get a bepposax source
         #coord = SkyCoord('14h32m00.0s -88d00m00.0s', frame='icrs')
 
+    df_lc = MultiIndexDFObject()
     for ccount, coord in enumerate(tqdm(coords_list)):
         #use astroquery to search that position for either a Fermi or Beppo Sax trigger
         for mcount, mission in enumerate(mission_list):

--- a/light_curves/code/icecube_functions.py
+++ b/light_curves/code/icecube_functions.py
@@ -16,7 +16,7 @@ import pandas as pd
 
 from astropy.time import Time
 
-from .data_structures import MultiIndexDFObject
+from data_structures import MultiIndexDFObject
 
 
 def icecube_get_lightcurve(coords_list, labels_list, object_names , icecube_select_topN , path , verbose):

--- a/light_curves/code/icecube_functions.py
+++ b/light_curves/code/icecube_functions.py
@@ -16,8 +16,10 @@ import pandas as pd
 
 from astropy.time import Time
 
+from .data_structures import MultiIndexDFObject
 
-def icecube_get_lightcurve(df_lc , coords_list, labels_list, object_names , icecube_select_topN , path , verbose):
+
+def icecube_get_lightcurve(coords_list, labels_list, object_names , icecube_select_topN , path , verbose):
     '''
     Extracts IceCube Neutrino events for a given source position and saves it into a lightcurve
     Pandas MultiIndex object.
@@ -25,10 +27,6 @@ def icecube_get_lightcurve(df_lc , coords_list, labels_list, object_names , icec
     
     Parameters
     ----------
-    df_lc : Lightcurve Pandas MultiIndex object
-        Lightcurve object to which to append the Gaia lightcurve. Must be created beforehand,
-        but can be an empty object.
-    
     coords_list : list of Astropy SkyCoord objects
         List of coordinates of the sources
     
@@ -84,6 +82,7 @@ def icecube_get_lightcurve(df_lc , coords_list, labels_list, object_names , icec
     icecube_matches = []
     icecube_matched = []
     ii = 0
+    df_lc = MultiIndexDFObject()
     for cc,coord in enumerate(coords_list):
 
         # get all distances

--- a/light_curves/code/panstarrs.py
+++ b/light_curves/code/panstarrs.py
@@ -5,7 +5,7 @@ import pandas as pd
 from tqdm import tqdm
 from astropy.io import ascii
 
-from .data_structures import MultiIndexDFObject
+from data_structures import MultiIndexDFObject
 
 
 def ps1cone(ra,dec,radius,table="mean",release="dr1",format="csv",columns=None,

--- a/light_curves/code/panstarrs.py
+++ b/light_curves/code/panstarrs.py
@@ -189,8 +189,8 @@ def panstarrs_get_lightcurves(coords_list, labels_list, radius):
     #for all objects in our catalog
     for ccount, coord in enumerate(tqdm(coords_list)):
         #doesn't take SkyCoord, convert to floats
-        ra = coords_list.ra.deg[ccount]
-        dec = coords_list.dec.deg[ccount]
+        ra = coord.ra.deg
+        dec = coord.dec.deg
         lab = labels_list[ccount]
 
         #sometimes there isn't actually a light curve for the target???

--- a/light_curves/code/panstarrs.py
+++ b/light_curves/code/panstarrs.py
@@ -5,6 +5,9 @@ import pandas as pd
 from tqdm import tqdm
 from astropy.io import ascii
 
+from .data_structures import MultiIndexDFObject
+
+
 def ps1cone(ra,dec,radius,table="mean",release="dr1",format="csv",columns=None,
            baseurl="https://catalogs.mast.stsci.edu/api/v0.1/panstarrs", verbose=False,
            **kw):
@@ -164,13 +167,11 @@ def search_lightcurve(objid):
 
 
 #Do a panstarrs search
-def panstarrs_get_lightcurves(df_lc, coords_list, labels_list, radius):
+def panstarrs_get_lightcurves(coords_list, labels_list, radius):
     """Searches panstarrs for light curves from a list of input coordinates
     
     Parameters
     ----------
-    df_lc : pandas multiindex dataframe
-        the main data structure to store all light curves
     coords_list : list of astropy skycoords
         the coordinates of the targets for which a user wants light curves
     labels_list: list of strings
@@ -184,6 +185,7 @@ def panstarrs_get_lightcurves(df_lc, coords_list, labels_list, radius):
         the main data structure to store all light curves
     """
         
+    df_lc = MultiIndexDFObject()
     #for all objects in our catalog
     for ccount, coord in enumerate(tqdm(coords_list)):
         #doesn't take SkyCoord, convert to floats

--- a/light_curves/code/sample_selection.py
+++ b/light_curves/code/sample_selection.py
@@ -386,8 +386,8 @@ def remove_duplicate_coords(skycoordslist, labels, verbose=1):
     uniquerows = table.unique(tjoin, keys = 'sc_id')
 
     #turn back into a list
-    sample_CLQ = uniquerows['sc_1']
-    labels_CLQ = uniquerows['label_1']
+    sample_CLQ = list(uniquerows['sc_1'])
+    labels_CLQ = list(uniquerows['label_1'])
     if verbose:
         print('after duplicates removal, sample size: '+str(len(sample_CLQ)))
         

--- a/light_curves/code/ztf_functions.py
+++ b/light_curves/code/ztf_functions.py
@@ -8,6 +8,9 @@ from alerce.core import Alerce
 from astropy.coordinates import SkyCoord, name_resolve
 import astropy.units as u
 
+from .data_structures import MultiIndexDFObject
+
+
 def ZTF_id2coord(object_ids,coords,labels,verbose=1):
     ''' To find and append coordinates of objects with only ZTF obj name'''
     alerce = Alerce()
@@ -20,11 +23,10 @@ def ZTF_id2coord(object_ids,coords,labels,verbose=1):
         print('number of ztf coords added by Objectname:',len(objects['meanra']))
     
 
-def ZTF_get_lightcurve(df_lc, coords_list,labels_list,ztf_radius = 0.000278, plotprint = 1): 
+def ZTF_get_lightcurve(coords_list,labels_list,ztf_radius = 0.000278, plotprint = 1):
     ''' Function to add the ZTF lightcurves in all three bands 
     to a multiframe data structure 
     input:
-     --- a multi-data frame to add the light curves to
      --- list of coordinates
      --- list of labels
      --- ztf_radius default to 0.000278
@@ -36,7 +38,8 @@ def ZTF_get_lightcurve(df_lc, coords_list,labels_list,ztf_radius = 0.000278, plo
 
     count_nomatch = 0 # counter for non matched objects
     count_plots = 0 
-    
+    df_lc = MultiIndexDFObject()
+
     for ccount, coord in enumerate(tqdm(coords_list)):
         #doesn't take SkyCoord
         ra = coord.ra.deg 

--- a/light_curves/code/ztf_functions.py
+++ b/light_curves/code/ztf_functions.py
@@ -23,7 +23,7 @@ def ZTF_id2coord(object_ids,coords,labels,verbose=1):
         print('number of ztf coords added by Objectname:',len(objects['meanra']))
     
 
-def ZTF_get_lightcurve(coords_list,labels_list,ztf_radius = 0.000278, plotprint = 1):
+def ZTF_get_lightcurve(coords_list, labels_list, plotprint=1, ztf_radius=0.000278):
     ''' Function to add the ZTF lightcurves in all three bands 
     to a multiframe data structure 
     input:

--- a/light_curves/code/ztf_functions.py
+++ b/light_curves/code/ztf_functions.py
@@ -8,7 +8,7 @@ from alerce.core import Alerce
 from astropy.coordinates import SkyCoord, name_resolve
 import astropy.units as u
 
-from .data_structures import MultiIndexDFObject
+from data_structures import MultiIndexDFObject
 
 
 def ZTF_id2coord(object_ids,coords,labels,verbose=1):


### PR DESCRIPTION
Included in this PR:

1. Change all `*_get_lightcurves()` functions so they no longer accept `df_lc` as an argument. Instead, each function creates its own `MultiIndexDFObject`, appends to that, and returns it. The `MultiIndexDFObject`s from each archive call can then be collected and concatenated into a single object. This makes the `*_get_lightcurves()` functions more self contained and safer for parallelization because it prevents processes from trying (and failing) to share the `df_lc` object.
2. Change `code.sample_selection.remove_duplicate_coords()` so that it returns `list`s. (Plus minor changes to some `*_get_lightcurves()` functions to accommodate.) Something in this function creates a weak reference instead of a real object, and a weak reference cannot be sent into a background process (because it cannot be pickled). Casting to a `list` creates a real object, and seems to be what was originally intended so that the output type matches the input.
3. Add import statements to individual `code` modules so that they don't rely on global imports.

This PR does not make changes to the main notebook, multiband_lc.ipynb, but the following is an example of what's envisioned.

## Usage

### 1. Setup (same as in multiband_lc.ipynb)

```python
import astropy.units as u
import pandas as pd
import sys
from math import ceil
from multiprocessing import Pool

sys.path.append("./unTimely_Catalog_explorer")
sys.path.append("code/")

from sample_selection import get_yang_sample, remove_duplicate_coords
from panstarrs import panstarrs_get_lightcurves
from gaia_functions import Gaia_get_lightcurve
from HCV_functions import HCV_get_lightcurves
from icecube_functions import icecube_get_lightcurve
from ztf_functions import ZTF_get_lightcurve
from data_structures import MultiIndexDFObject
from heasarc_functions import HEASARC_get_lightcurves
from TESS_Kepler_functions import TESS_Kepler_get_lightcurves
from WISE_functions import WISE_get_lightcurves


# define some variables
mission_list = ["FERMIGTRIG", "SAXGRBMGRB"]
heasarc_radius = 0.1 * u.degree
bandlist = ["w1", "w2"]
wise_radius = 1.0
panstarrs_radius = 1.0 / 3600.0  # search radius = 1 arcsec
lk_radius = 1.0  # arcseconds
hcv_radius = 1.0 / 3600.0  # radius = 1 arcsec

# build up the sample
coords, labels = [], []
get_yang_sample(coords, labels)
coords_list, labels_list = remove_duplicate_coords(coords, labels)
object_names = [["CLAGN" + str(i)] for i in range(len(coords_list))]
```

### 2. Query archives in parallel

This uses [multiprocessing.Pool.apply_async](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.pool.Pool.apply_async). We want one worker process per call to `apply_async`. Total number of workers can be larger than the number of CPUs available because most calls use a relatively small amount of CPU and memory resources. Of note:

- WISE call uses more CPU than most. Parallelization will likely be limited by number of CPUs available. Plan on 1 CPU per call to `WISE_get_lightcurves`.
- ZTF call spends most of the time waiting for a response and using almost no CPU/memory resources. Parallelization will likely be limited by the ZTF service itself.

```python
# calculate the number of workers needed.
# these two must sum to total number of archives called
n_fast_archives, n_slow_archives = 6, 2
# coords_list will be split into this many chunks. we'll make one api call per chunk per slow archive
n_chunks_per_slow_archive = 15
# number of workers
n_workers = n_fast_archives + n_slow_archives * n_chunks_per_slow_archive

# MultiIndexDFObject to collect dataframes returned by each archive call
# only the main process will append to this, via the `append_df_lc` callback
df_lc = MultiIndexDFObject()

def append_df_lc(archive_df_lc):
    """Append `archive_df_lc` to `df_lc`. When a `pool.apply_async` call completes, 
    this function will be called on the result (`archive_df_lc`).
    """
    try:
        df_lc.append(archive_df_lc.data)
    except AttributeError:
        # this archive call returned no data
        pass

# start a multiprocessing pool and run all the archive queries
# without ztf this takes less than 2 min
# ztf can take significantly longer (maybe needs fewer simultaneous calls?)
with Pool(processes=n_workers) as pool:

    # start the processes that call the fast archives
    pool.apply_async(
        Gaia_get_lightcurve, (coords_list, labels_list, object_names, 1), callback=append_df_lc
    )
    pool.apply_async(
        HEASARC_get_lightcurves, (coords_list, labels_list, heasarc_radius, mission_list), callback=append_df_lc
    )
    pool.apply_async(
        HCV_get_lightcurves, (coords_list, labels_list, hcv_radius), callback=append_df_lc
    )
    pool.apply_async(
        icecube_get_lightcurve, (coords_list, labels_list, object_names, 3, "./data/", 1), callback=append_df_lc
    )
    pool.apply_async(
        panstarrs_get_lightcurves, (coords_list, labels_list, panstarrs_radius), callback=append_df_lc
    )
    pool.apply_async(
        TESS_Kepler_get_lightcurves, (coords_list, labels_list, lk_radius), callback=append_df_lc
    )

    # split coords_list into smaller chunks and call slow archives
    chunksize = ceil(len(coords_list) / n_chunks_per_slow_archive)  # num coords per api call
    for n in range(0, len(coords_list), chunksize):
        coords = coords_list[n : n + chunksize]
        labels = labels_list[n : n + chunksize]

        # start the processes that call the slow archives
        pool.apply_async(
            WISE_get_lightcurves, (coords, labels, wise_radius, bandlist), callback=append_df_lc
        )
        pool.apply_async(
            ZTF_get_lightcurve, (coords, labels, 0), callback=append_df_lc
        )

    pool.close()  # signal that no more jobs will be submitted to the pool
    pool.join()  # wait for all jobs to complete, including the callback (append_df_lc)

# look at the result
df_lc.data.sample(10)
```