### PR TITLE
Updates to enable full run

### DIFF
--- a/forced_photometry/multiband_photometry.ipynb
+++ b/forced_photometry/multiband_photometry.ipynb
@@ -158,6 +158,7 @@
     "from astroquery.ipac.irsa import Irsa\n",
     "from astroquery.heasarc import Heasarc\n",
     "from astroquery.mast import Observations\n",
+    "import pyvo\n",
     "\n",
     "# Local code imports\n",
     "sys.path.append('../code/')\n",
@@ -214,6 +215,7 @@
     "Irsa.ROW_LIMIT = 3E6  \n",
     "Irsa.TIMEOUT = 600\n",
     "\n",
+    "#pull a COSMOS catalog from IRSA using pyvo\n",
     "\n",
     "#what is the central RA and DEC of the desired catalog\n",
     "coords = SkyCoord('150.01d 2.2d', frame='icrs')  #COSMOS center acording to Simbad\n",
@@ -232,7 +234,16 @@
     "    'r_MAGERR_AUTO', 'FLUX_24', 'FLUXERR_24', 'MAG_GALEX_NUV', 'MAGERR_GALEX_NUV',\n",
     "    'MAG_GALEX_FUV', 'MAGERR_GALEX_FUV'\n",
     "]\n",
-    "cosmos_table = Irsa.query_region(coords, catalog=\"cosmos2015\", radius=radius, selcols=','.join(cols))\n",
+    "#cosmos_table = Irsa.query_region(coords, catalog=\"cosmos2015\", radius=radius, selcols=','.join(cols))\n",
+    "\n",
+    "# The above line works for radius<=40arcmin; for the full 48arcmin; do it with pyvo\n",
+    "tap = pyvo.dal.TAPService('https://irsa.ipac.caltech.edu/TAP')\n",
+    "result = tap.run_sync(\"\"\"\n",
+    "           SELECT {}\n",
+    "           FROM cosmos2015\n",
+    "           WHERE CONTAINS(POINT('ICRS',ra, dec), CIRCLE('ICRS',{}, {}, {}))=1\n",
+    "    \"\"\".format(','.join(cols), coords.ra.value, coords.dec.value, radius.value/60.))\n",
+    "cosmos_table = result.to_table()\n",
     "\n",
     "\n",
     "print(\"Number of objects: \", len(cosmos_table))\n"
@@ -1211,7 +1222,8 @@
     "        img_pair = lookup_img_pair(sci_bkg_pairs, band.idx, row.galex_image)  # file paths only\n",
     "        paramlist.append(\n",
     "            [row.Index, band, row.ra, row.dec, row.type, row.ks_flux_aper2, img_pair, df]\n",
-    "        )            "
+    "        )\n",
+    "print('paramlist: ', len(paramlist))"
    ]
   },
   {
@@ -1256,8 +1268,10 @@
     "#wrapper to measure the photometry on a single object, single band\n",
     "def calculate_flux(args):\n",
     "    \"\"\"Calculate flux.\"\"\"\n",
-    "    f = calc_instrflux\n",
-    "    val = f(*args[1:])\n",
+    "    val = calc_instrflux(*args[1:])\n",
+    "    # add simple logging\n",
+    "    if (args[0] % 100) == 0 and val[0] == 0:\n",
+    "        with open('output.log', 'a') as fp: fp.write(f'{args[0]}\\n')\n",
     "    return(args[0], val)"
    ]
   },
@@ -1267,21 +1281,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%time\n",
-    "#Here is where the multiprocessing work gets done\n",
-    "t2 = time.time()\n",
-    "outputs = []\n",
-    "# number of processes can be controlled with a max_workers arg in ProcessPoolExecutor\n",
-    "# defaults to the number of available processors, beyond which no performance gains are seen\n",
-    "with concurrent.futures.ProcessPoolExecutor() as executor:\n",
-    "    for result in list(tqdm(executor.map(calculate_flux, paramlist), total = len(paramlist))):\n",
-    "        # print(result)\n",
-    "        df.loc[result[0],\n",
-    "                  'ch{:d}flux'.format(result[1][0] + 1)] = result[1][1]\n",
-    "        df.loc[result[0],\n",
-    "                  'ch{:d}flux_unc'.format(result[1][0] + 1)] = result[1][2]\n",
-    "        outputs.append(result)\n",
-    "t3 = time.time()"
+    "fname = f'results_{radius.value}.npz'\n",
+    "if os.path.exists(fname):\n",
+    "    results = np.load(fname, allow_pickle=True)['results']\n",
+    "else:\n",
+    "    from  multiprocessing import Pool\n",
+    "    t0 = time.time()\n",
+    "    with open('output.log', 'w') as fp: fp.write('')\n",
+    "    with Pool() as pool:\n",
+    "        results = pool.map(calculate_flux, paramlist)\n",
+    "    dtime = time.time() - t0\n",
+    "    np.savez(fname, results=results)\n",
+    "    print(f'Parallel calculation took {dtime} seconds')"
    ]
   },
   {
@@ -1290,11 +1301,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#print('Serial calculation took {:.2f} seconds'.format((t1 - t0)))\n",
-    "print('Parallel calculation took {:.2f} seconds'.format((t3 - t2)))\n",
-    "#print('Speedup is {:.2f}'.format((t1 - t0) / (t3 - t2)))\n",
-    "\n",
-    "#speedup was factors of 10 - 12 for 400 - 10000 sources"
+    "## put the results into the main daraframe\n",
+    "for res in results:\n",
+    "    idx,(ich, val, err) = res\n",
+    "    df.loc[idx, f'ch{ich+1}flux'] = val\n",
+    "    df.loc[idx, f'ch{ich+1}flux_unc'] = err"
    ]
   },
   {
@@ -1304,8 +1315,6 @@
    "outputs": [],
    "source": [
     "#Count the number of non-zero ch1 fluxes\n",
-    "#print('Serial calculation: number of ch1 fluxes filled in =',\n",
-    "#      np.sum(df.ch1flux > 0))\n",
     "print('Parallel calculation: number of ch1 fluxes filled in =',\n",
     "      np.sum(df.ch1flux > 0))"
    ]
@@ -1326,8 +1335,7 @@
     "#had to call the galex flux columns ch5 and ch6\n",
     "#fix that by renaming them now\n",
     "cols = {'ch5flux':'nuvflux', 'ch5flux_unc':'nuvflux_unc','ch6flux':'fuvflux', 'ch6flux_unc':'fuvflux_unc'}\n",
-    "df.rename(columns=cols, inplace = True)\n",
-    "#pl_df.rename(columns={'ch5flux':'nuvflux', 'ch5flux_unc':'nuvflux_unc','ch6flux':'fuvflux', 'ch6flux_unc':'fuvflux_unc'}, inplace = True)"
+    "df.rename(columns=cols, inplace = True)"
    ]
   },
   {
@@ -1339,7 +1347,8 @@
     "#When doing a large run of a large area, save the dataframe with the forced photometry \n",
     "# so we don't have to do the forced photometry every time\n",
     "\n",
-    "df.to_pickle('../data/COSMOS_15arcmin.pkl')\n",
+    "df.to_pickle(f'../data/COSMOS_{radius.value}arcmin.pkl')\n",
+    "\n",
     "\n"
    ]
   },
@@ -1716,7 +1725,7 @@
     "#plt.legend([],[], frameon=False)\n",
     "\n",
     "#fig.savefig(\"../data/color_color.png\")\n",
-    "mpld3.display(fig)  \n"
+    "#mpld3.display(fig)  \n"
    ]
   },
   {


### PR DESCRIPTION
The main updates are:
- Switched the first `cosmos2015` query to use TAP service with pyvo instead of astroquery. The latter was using a lot of memory when requesting the full table.
- Switched from `concurrent` to `multiprocessing` when running the tractor in parallel. The main dataframe is now updated with the results after the whole run is complete instead of doing it inside the loop. These appear to prevent the staling. I don't know exactly why. 
- I added the draft `pyvo` version that deals with the cloud columns. It is not fully working yet, but it should be added for the final demo