### PR TITLE
Get ZTF data from parquet files instead of light curve service

### DIFF
--- a/light_curves/code/ztf_functions.py
+++ b/light_curves/code/ztf_functions.py
@@ -1,43 +1,24 @@
+import re
+
+import astropy.units as u
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import requests
-from alerce.core import Alerce
 from astropy.coordinates import SkyCoord
-from astropy.io import ascii
-from tqdm import tqdm
-
+from astropy.table import Table, vstack
 from data_structures import MultiIndexDFObject
+from tqdm import tqdm
+from zort import radec
 
 
-def ZTF_id2coord(object_ids,coords,labels,verbose=1):
-    """ To find and append coordinates of objects with only ZTF obj name
-      
-    Parameters
-    ----------
-    object_ids: list of strings
-        eg., [ "ZTF18accqogs", "ZTF19aakyhxi", "ZTF19abyylzv", "ZTF19acyfpno"]
-    coords : list of astropy skycoords
-        the coordinates of the targets for which a user wants light curves
-    labels: list of strings
-        journal articles associated with the target coordinates
-    verbose: int
-        print out debugging info (1) or not(0)
-    """
-    
-    
-    
-    alerce = Alerce()
-    objects = alerce.query_objects(oid=object_ids, format="pandas")
-    ztf_coords = [SkyCoord(ra, dec, frame='icrs', unit='deg') for ra, dec in zip(objects['meanra'],objects['meandec'])]
-    ztf_labels = ['ZTF-Objname' for ra in objects['meanra']]
-    coords.extend(ztf_coords)
-    labels.extend(ztf_labels)
-    if verbose:
-        print('number of ztf coords added by Objectname:',len(objects['meanra']))
-    
+URLBASE = "https://irsa.ipac.caltech.edu/data/ZTF/lc/lc_dr17"
+# get a list of files in the dataset using the checksums file
+DSFILES = pd.read_table(
+        f"{URLBASE}/checksum.md5", sep="\s+", names=["md5", "path"], usecols=["path"]
+    ).squeeze().str.removeprefix("./").to_list()
 
-def ZTF_get_lightcurve(coords_list, labels_list, plotprint=1, ztf_radius=0.000278):
+
+def ZTF_get_lightcurve(coords_list, labels_list, plotprint=1, ztf_radius=0.000278*u.deg):
     """ Function to add the ZTF lightcurves in all three bands to a multiframe data structure 
      
     Parameters
@@ -61,63 +42,110 @@ def ZTF_get_lightcurve(coords_list, labels_list, plotprint=1, ztf_radius=0.00027
     count_plots = 0 
     df_lc = MultiIndexDFObject()
 
-    for objectid, coord in tqdm(coords_list):
-        #doesn't take SkyCoord
-        ra = coord.ra.deg 
-        dec = coord.dec.deg 
-        lab = labels_list[objectid]
-        #make the string for the URL query ask for all three bands (g, r, i)
-        #don't want data that is flagged as unusable by the ZTF pipeline
-        urlstr = 'https://irsa.ipac.caltech.edu/cgi-bin/ZTF/nph_light_curves?POS=CIRCLE %f %f %f&BANDNAME=g,r,i&FORMAT=ipac_table&BAD_CATFLAGS_MASK=32768'%(ra, dec,ztf_radius)
-        response = requests.get(urlstr)
-        if response.ok:
-            ztf_lc = ascii.read(response.text, format='ipac')
-            if len(np.unique(ztf_lc['oid']))>0:
-                # reading in indecies of unique IDs to do coordinate match and find dif magnitudes of same objects 
-                idu,inds = np.unique(ztf_lc['oid'],return_index=True)
+    for oid, coord in tqdm(coords_list):
+        lab = labels_list[oid]
+
+        # find which files this object is in. this line takes about 30 sec
+        files = find_files(coord)  # 30 sec
+
+        # load everything in the files and use astropy to find the object
+        # these 3 lines take about 1 sec total
+        ztf_lc = vstack([Table.read(file) for file in files])  # 1 sec
+        ztf_coords = SkyCoord(ra=ztf_lc["objra"] * u.deg, dec=ztf_lc["objdec"] * u.deg)  # 8 ms
+        ztf_lc = ztf_lc[coord.separation(ztf_coords) < ztf_radius]  # 20 ms
+        # remove data flagged as bad. 
+        # this doesn't work because of the nested structure, but the structure causes more 
+        # problems later on and we'll need to think through a solution. punting for now.
+        # ztf_lc = ztf_lc[ztf_lc["catflags"] != 32768]
+
+        # add some columns that are used below
+        ztf_lc["oid"] = ztf_lc["objectid"]
+        ztf_lc["mjd"] = ztf_lc["hmjd"]  # this isn't right but leaving it for now
+        filter_dict = {1: "zg", 2: "zr", 3: "zi"}
+        ztf_lc["filtercode"] = [filter_dict[fid] for fid in ztf_lc["filterid"]]
+        
+        # the rest of this doesn't work yet because this new ztf_lc has nested columns
+        # and the code below expects a different shape
+
+        if len(np.unique(ztf_lc['oid']))>0:
+            # reading in indecies of unique IDs to do coordinate match and find dif magnitudes of same objects 
+            idu,inds = np.unique(ztf_lc['oid'],return_index=True)
+            if count_plots<plotprint:
+                print('object '+str(oid)+' , unique ztf IDs:'+str(len(np.unique(ztf_lc['oid'])))+',in '+str(len(np.unique(ztf_lc['filtercode'])))+' filters')
+                plt.figure(figsize=(6,4))
+            
+            ## Neeeded to remove repeated lightcurves in each band. Will keep only the longest following (Sanchez-Saez et al., 2021)
+            filternames = ['zg','zr','zi']
+            filtercounter = [0,0,0] #[g,r,i]
+            filterflux = [[],[],[]]
+
+            for nn,idd in enumerate(idu):
+                sel = (ztf_lc['oid']==idd)
+
+                flux = 10**((ztf_lc['mag'][sel] - 23.9)/(-2.5))  #now in uJy [Based on ztf paper https://arxiv.org/pdf/1902.01872.pdf zeropoint corrections already applied]
+                magupper = ztf_lc['mag'][sel] + ztf_lc['magerr'][sel]
+                maglower = ztf_lc['mag'][sel] - ztf_lc['magerr'][sel]
+                flux_upper = abs(flux - (10**((magupper - 23.9)/(-2.5))))
+                flux_lower =  abs(flux - (10**((maglower - 23.9)/(-2.5))))
+                fluxerr = (flux_upper + flux_lower) / 2.0
+                flux = flux * (1E-3) # now in mJy
+                fluxerr = fluxerr * (1E-3) # now in mJy
                 if count_plots<plotprint:
-                    print('object '+str(objectid)+' , unique ztf IDs:'+str(len(np.unique(ztf_lc['oid'])))+',in '+str(len(np.unique(ztf_lc['filtercode'])))+' filters')
-                    plt.figure(figsize=(6,4))
+                    plt.errorbar(np.round(ztf_lc['mjd'][sel],0),flux,yerr=fluxerr,marker='.',linestyle='',label=ztf_lc['filtercode'][sel][0])
+                    plt.legend()
+                # if a band is observed before and this has longer lightcurve, remove previous and add this one
+                if (filtercounter[filternames.index(ztf_lc['filtercode'][sel][0])]>=1) and (len(flux)<=len(filterflux[filternames.index(ztf_lc['filtercode'][sel][0])])):
+                    #print('1st loop, filter'+str(ztf_lc['filtercode'][sel][0])+' len:'+str(len(flux)))
+                    filtercounter[filternames.index(ztf_lc['filtercode'][sel][0])]+=1
+                elif (filtercounter[filternames.index(ztf_lc['filtercode'][sel][0])]>=1) and (len(flux)>len(filterflux[filternames.index(ztf_lc['filtercode'][sel][0])])):
+                    #print('2nd loop, filter'+str(ztf_lc['filtercode'][sel][0])+' len:'+str(len(flux)))
+                    df_lc.remove((oid, lab, ztf_lc["filtercode"][sel][0]))
+                    dfsingle = pd.DataFrame(dict(flux=flux, err=fluxerr, time=ztf_lc['mjd'][sel], oid=oid, band=ztf_lc['filtercode'][sel][0], label=lab)).set_index(["oid","label", "band", "time"])
+                    df_lc.append(dfsingle)
+                else:
+                    #print('3rd filter'+str(ztf_lc['filtercode'][sel][0])+' len:'+str(len(flux)))
+                    dfsingle = pd.DataFrame(dict(flux=flux, err=fluxerr, time=ztf_lc['mjd'][sel], oid=oid, band=ztf_lc['filtercode'][sel][0], label=lab)).set_index(["oid" ,"label","band", "time"])
+                    df_lc.append(dfsingle)
+                    filtercounter[filternames.index(ztf_lc['filtercode'][sel][0])]+=1
+                    filterflux[filternames.index(ztf_lc['filtercode'][sel][0])]=flux
                 
-                ## Neeeded to remove repeated lightcurves in each band. Will keep only the longest following (Sanchez-Saez et al., 2021)
-                filternames = ['zg','zr','zi']
-                filtercounter = [0,0,0] #[g,r,i]
-                filterflux = [[],[],[]]
-            
-                for nn,idd in enumerate(idu):
-                    sel = (ztf_lc['oid']==idd)
-            
-                    flux = 10**((ztf_lc['mag'][sel] - 23.9)/(-2.5))  #now in uJy [Based on ztf paper https://arxiv.org/pdf/1902.01872.pdf zeropoint corrections already applied]
-                    magupper = ztf_lc['mag'][sel] + ztf_lc['magerr'][sel]
-                    maglower = ztf_lc['mag'][sel] - ztf_lc['magerr'][sel]
-                    flux_upper = abs(flux - (10**((magupper - 23.9)/(-2.5))))
-                    flux_lower =  abs(flux - (10**((maglower - 23.9)/(-2.5))))
-                    fluxerr = (flux_upper + flux_lower) / 2.0
-                    flux = flux * (1E-3) # now in mJy
-                    fluxerr = fluxerr * (1E-3) # now in mJy
-                    if count_plots<plotprint:
-                        plt.errorbar(np.round(ztf_lc['mjd'][sel],0),flux,yerr=fluxerr,marker='.',linestyle='',label=ztf_lc['filtercode'][sel][0])
-                        plt.legend()
-                    # if a band is observed before and this has longer lightcurve, remove previous and add this one
-                    if (filtercounter[filternames.index(ztf_lc['filtercode'][sel][0])]>=1) and (len(flux)<=len(filterflux[filternames.index(ztf_lc['filtercode'][sel][0])])):
-                        #print('1st loop, filter'+str(ztf_lc['filtercode'][sel][0])+' len:'+str(len(flux)))
-                        filtercounter[filternames.index(ztf_lc['filtercode'][sel][0])]+=1
-                    elif (filtercounter[filternames.index(ztf_lc['filtercode'][sel][0])]>=1) and (len(flux)>len(filterflux[filternames.index(ztf_lc['filtercode'][sel][0])])):
-                        #print('2nd loop, filter'+str(ztf_lc['filtercode'][sel][0])+' len:'+str(len(flux)))
-                        df_lc.remove((objectid, lab, ztf_lc["filtercode"][sel][0]))
-                        dfsingle = pd.DataFrame(dict(flux=flux, err=fluxerr, time=ztf_lc['mjd'][sel], objectid=objectid, band=ztf_lc['filtercode'][sel][0], label=lab)).set_index(["objectid","label", "band", "time"])
-                        df_lc.append(dfsingle)
-                    else:
-                        #print('3rd filter'+str(ztf_lc['filtercode'][sel][0])+' len:'+str(len(flux)))
-                        dfsingle = pd.DataFrame(dict(flux=flux, err=fluxerr, time=ztf_lc['mjd'][sel], objectid=objectid, band=ztf_lc['filtercode'][sel][0], label=lab)).set_index(["objectid" ,"label","band", "time"])
-                        df_lc.append(dfsingle)
-                        filtercounter[filternames.index(ztf_lc['filtercode'][sel][0])]+=1
-                        filterflux[filternames.index(ztf_lc['filtercode'][sel][0])]=flux
-                    
-                if count_plots<plotprint:
-                    plt.show()
-                    count_plots+=1
-            else:
-                count_nomatch+=1
+            if count_plots<plotprint:
+                plt.show()
+                count_plots+=1
+        else:
+            count_nomatch+=1
     print(count_nomatch,' objects did not match to ztf')
     return df_lc
+
+
+def parse_rcid(rcid):
+    """Return CCD and quadrant, where rcid = 4 * (CCD - 1) + (quadrant - 1).
+    See:  https://irsa.ipac.caltech.edu/data/ZTF/docs/common/ztf_focal_plane.jpg
+    """
+    ccd = rcid // 4 + 1
+    quad = rcid % 4 + 1
+    return ccd, quad
+
+
+def find_files(coord):
+    """Return list of files containing this coord.
+    The dataset is partitioned by ztf field, ccd, quadrant, and filter.
+    """
+    # find the ztf field, ccd, and quadrant. needed to id which files contain the object.
+    # radec.return_fields is the specific call that takes 30 seconds
+    fields = radec.return_fields(coord.ra.deg, coord.dec.deg)
+    fcq = []  # will hold tuples of (field, ccd, quadrant)
+    for field in fields:
+        rcid = radec.return_rcid(field, coord.ra.deg, coord.dec.deg)
+        if rcid is not None:
+            fcq.append((str(field).zfill(6), *parse_rcid(rcid)))
+
+    # now find the files
+    files = []
+    for field, ccd, quad in fcq:
+        fre = re.compile(
+            f"[01]/field{field}/ztf_{field}_z[gri]_c{ccd}_q{quad}_dr17.parquet"
+        )
+        files.extend([f"{URLBASE}/{f}" for f in filter(fre.match, DSFILES)])
+
+    return files

--- a/light_curves/requirements.txt
+++ b/light_curves/requirements.txt
@@ -13,4 +13,4 @@ alerce
 wget
 git+https://github.com/fkiwy/unTimely_Catalog_explorer
 reproject  # needed for untimely
-
+zort


### PR DESCRIPTION
Note: I am using this PR as a demonstration of this data access method for informational and discussion purposes. I do not intend to actually merge it.

The current bottleneck in scaling up the light curve notebook is the ZTF light curve service, so we're looking at other options to get the data (see #107). This PR switches the data access method in `ZTF_get_lightcurve` to use the ZTF [parquet files](https://irsa.ipac.caltech.edu/data/ZTF/lc/lc_dr17/). 

The parquet files are organized by ZTF field, CCD, quadrant, and filter. Unfortunately, the only method I could find to lookup which files contain a given object (ra/dec) is far too slow, taking more than 30 seconds per object. If we are going to use parquet files, I think we should repartition them to be the same as the others we're currently doing (i.e., by HEALPix order 5). There are other options for getting the data, like alert brokers or others in the community, so we're looking into those as well.

I'll leave this open for a few days, in case anyone wants to comment. Then I'll close it. Pinging @xoubish @jkrick @stargaser @bsipocz 