### PR TITLE
BUG: fix irsa download bits, requires new fornax

### DIFF
--- a/forced_photometry/multiband_photometry.ipynb
+++ b/forced_photometry/multiband_photometry.ipynb
@@ -356,7 +356,10 @@
     "        if fname_filter is not None and fname_filter not in row['fname']:\n",
     "            continue\n",
     "        handler = fornax.get_data_product(row, 'aws', access_url_column=access_url_column, verbose=verbose)\n",
-    "        handler.download()\n",
+    "        temp_file = handler.download()\n",
+    "        # on-prem download returns temp file path, s3 download downloads file\n",
+    "        if temp_file:\n",
+    "            os.rename(temp_file, os.path.basename(row['fname']))\n",
     "        \n",
     "    os.chdir(working_dir)"
    ]


### PR DESCRIPTION
I've merged the changes required to make this work, this PR fixed the download part for the on-prem fall-back case. I'm still running into some authentication-related issues when trying to run it locally with credentials to the bucket, I suspect it may have a different behavior on daskhub, and yet another different behaviour (e.g. it should work) if we switch to an open bucket.

So, I propose to move on with merging it, this ticks the box of making the notebook pass through this cell, and adds incremental changes. In a new one I'll cover the other cases (restricted bucket access with credentials, properly fall back on on-prem when there is an issue with credentials, and ultimately making it work with an open bucket).

I'm making these changes deliberately small and separate, so we less likely run into complicated conflicts when multiple of us are working on the same notebook.