### PR TITLE
Use SIA/Fornax instead of Astroquery for Galex access

### DIFF
--- a/forced_photometry/multiband_photometry.ipynb
+++ b/forced_photometry/multiband_photometry.ipynb
@@ -138,6 +138,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Specify the COSMOS coordinates for use in upcoming queries.\n",
+    "coords = SkyCoord('150.01d 2.2d', frame='icrs')  #COSMOS center acording to Simbad"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "#pull a COSMOS catalog from IRSA using astroquery\n",
     "\n",
     "#make sure the archive isn't limiting our search\n",
@@ -146,9 +156,6 @@
     "Irsa.TIMEOUT = 600\n",
     "\n",
     "#pull a COSMOS catalog from IRSA using pyvo\n",
-    "\n",
-    "#what is the central RA and DEC of the desired catalog\n",
-    "coords = SkyCoord('150.01d 2.2d', frame='icrs')  #COSMOS center acording to Simbad\n",
     "\n",
     "#how large is the search radius, in arcmin\n",
     "radius = 48.0 * u.arcmin #full COSMOS is 40arcmin\n",
@@ -336,8 +343,6 @@
     "ra_center=[150.369,150.369,149.869,149.869]\n",
     "dec_center=[2.45583,1.95583,2.45583,1.95583]\n",
     "\n",
-    "#ra_center = 150.369\n",
-    "#dec_center = 2.45583\n",
     "galex = SkyCoord(ra = ra_center*u.degree, dec = dec_center*u.degree)\n",
     "catalog = SkyCoord(ra = cosmos_table['ra'], dec = cosmos_table['dec'])\n",
     "#idx, d2d, d3d = match_coordinates_sky(galex, catalog)  #only finds the nearest one\n",
@@ -371,13 +376,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Discover Galex mosaics from MAST using its IVOA Simple Image Access service.\n",
-    "pos = SkyCoord(150.01, 2.20, unit=\"deg\")\n",
-    "\n",
-    "# TODO:  Discover this service in the registry.\n",
+    "# Assign the endpoint for the MAST Galex Simple Image Access service.\n",
     "galex_sia_url = 'https://mast.stsci.edu/portal_vo/Mashup/VoQuery.asmx/SiaV1?MISSION=GALEX&'\n",
     "\n",
-    "query_result = pyvo.dal.sia.search(galex_sia_url, pos=pos, size=0.0)\n",
+    "# Query the Galex SIA service using the COSMOS coordinates defined above.\n",
+    "query_result = pyvo.dal.sia.search(galex_sia_url, pos=coords, size=0.0)\n",
     "galex_image_products = query_result.to_table()\n",
     "\n",
     "# Filter the products so we only download SCIENCE products with exposure time > 40000\n",
@@ -399,7 +402,6 @@
    "outputs": [],
    "source": [
     "# Get the GALEX sky background fits files in addition to the mosaics\n",
-    "# TODO: clean this up to be less arbitrary\n",
     "skybg_products = []\n",
     "skybkg_pattern = re.compile(r\"COSMOS_0[1-4]-[fn]d-skybg\")\n",
     "\n",

--- a/forced_photometry/multiband_photometry.ipynb
+++ b/forced_photometry/multiband_photometry.ipynb
@@ -1261,9 +1261,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python [conda env:tractor]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-tractor-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1275,7 +1275,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.10.6"
   },
   "toc": {
    "base_numbering": 1,

--- a/forced_photometry/multiband_photometry.ipynb
+++ b/forced_photometry/multiband_photometry.ipynb
@@ -138,16 +138,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Specify the COSMOS coordinates for use in upcoming queries.\n",
-    "coords = SkyCoord('150.01d 2.2d', frame='icrs')  #COSMOS center acording to Simbad"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "#pull a COSMOS catalog from IRSA using astroquery\n",
     "\n",
     "#make sure the archive isn't limiting our search\n",
@@ -156,6 +146,9 @@
     "Irsa.TIMEOUT = 600\n",
     "\n",
     "#pull a COSMOS catalog from IRSA using pyvo\n",
+    "\n",
+    "#what is the central RA and DEC of the desired catalog\n",
+    "coords = SkyCoord('150.01d 2.2d', frame='icrs')  #COSMOS center acording to Simbad\n",
     "\n",
     "#how large is the search radius, in arcmin\n",
     "radius = 48.0 * u.arcmin #full COSMOS is 40arcmin\n",

--- a/forced_photometry/multiband_photometry.ipynb
+++ b/forced_photometry/multiband_photometry.ipynb
@@ -319,7 +319,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Use astroquery.mast to obtain Galex from the MAST archive"
+    "#### Use IVOA image search and Fornax download to obtain Galex from the MAST archive"
    ]
   },
   {
@@ -371,33 +371,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#pull Galex mosaics from MAST\n",
-    "# Get the observations you want\n",
-    "in_coordinates = '150.01 2.20'\n",
-    "observations = Observations.query_criteria(coordinates=in_coordinates, instrument_name='GALEX')\n",
+    "# Discover Galex mosaics from MAST using its IVOA Simple Image Access service.\n",
+    "pos = SkyCoord(150.01, 2.20, unit=\"deg\")\n",
     "\n",
-    "filtered_observations = observations[(observations['t_exptime'] > 40000.0)]\n",
+    "# TODO:  Discover this service in the registry.\n",
+    "galex_sia_url = 'https://mast.stsci.edu/portal_vo/Mashup/VoQuery.asmx/SiaV1?MISSION=GALEX&'\n",
     "\n",
-    "# Get the products for these observations \n",
-    "products = Observations.get_product_list(filtered_observations)\n",
+    "query_result = pyvo.dal.sia.search(galex_sia_url, pos=pos, size=0.0)\n",
+    "galex_image_products = query_result.to_table()\n",
     "\n",
-    "# Filter the products so we only download SCIENCE products\n",
-    "filtered_products = Observations.filter_products(\n",
-    "    products, productType='SCIENCE', productGroupDescription='Minimum Recommended Products'\n",
-    ")\n",
+    "# Filter the products so we only download SCIENCE products with exposure time > 40000\n",
+    "filtered_products = galex_image_products[(galex_image_products['timExposure'] > 40000.0)]\n",
+    "filtered_products = filtered_products[(filtered_products['productType'] == \"SCIENCE\")]\n",
     "\n",
-    "# Enable cloud access\n",
-    "Observations.enable_cloud_dataset(provider='AWS')\n",
+    "# The column containing the on-prem access to fall back on if cloud is unavailable\n",
+    "access_url_column = query_result.fieldname_with_ucd('VOX:Image_AccessReference')\n",
     "\n",
-    "# Download filtered products\n",
-    "# Then, as a temporarily measure, flatten out the directory structure with symlinks (to avoid downloading again)\n",
+    "# Download filtered products from AWS\n",
     "download_dir = '../data/Galex/'\n",
-    "downloaded_galex = Observations.download_products(filtered_products, cloud_only=True, download_dir=download_dir) \n",
-    "\n",
-    "for infile in downloaded_galex['Local Path']:\n",
-    "    flat_file_path = f'{download_dir}/{os.path.basename(infile)}'\n",
-    "    if not os.path.exists(flat_file_path):\n",
-    "        os.symlink(re.split(download_dir, infile)[1], flat_file_path)"
+    "fornax_download(filtered_products, access_url_column=access_url_column, data_directory=download_dir)"
    ]
   },
   {
@@ -406,23 +398,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Get the GALEX skybg fits files in addition to the mosaics\n",
-    "\n",
-    "in_coordinates = '150.01 2.20'\n",
-    "observations = Observations.query_criteria(coordinates=in_coordinates, instrument_name='GALEX')\n",
-    "\n",
-    "# get products of said observations \n",
-    "products = Observations.get_product_list(observations)\n",
-    "\n",
-    "# filtering for the few products we know we need, TODO: clean this up to be less arbitrary\n",
+    "# Get the GALEX sky background fits files in addition to the mosaics\n",
+    "# TODO: clean this up to be less arbitrary\n",
     "skybg_products = []\n",
     "skybkg_pattern = re.compile(r\"COSMOS_0[1-4]-[fn]d-skybg\")\n",
     "\n",
-    "for row in products['dataURI']:\n",
-    "    if skybkg_pattern.search(row): \n",
+    "for row in galex_image_products:\n",
+    "    if skybkg_pattern.search(row['name']):\n",
     "        skybg_products.append(row)\n",
-    "        # local_path has to be a filename, see bug https://github.com/astropy/astroquery/issues/2501\n",
-    "        Observations.download_file(row, local_path=f'../data/Galex/{os.path.basename(row)}') "
+    "\n",
+    "# Download skybg products from AWS\n",
+    "download_dir = '../data/Galex/'\n",
+    "fornax_download(skybg_products, access_url_column=access_url_column, data_directory=download_dir)"
    ]
   },
   {
@@ -1272,9 +1259,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:tractor]",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "conda-env-tractor-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1286,7 +1273,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.9.16"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
I've updated the prototype SIA service at MAST to support Galex.  This PR replaces 2 cells in the notebook to use pyvo and the Fornax cloud access API instead of Astroquery to find and download from S3 the same Galex products.

One optional TODO is that I can register the SIA service so that it can be discovered with pyvo instead of hardcoding the service URL.

I don't know if the notebook metadata changes matter but can probably remove them if needed.