### PR TITLE
Heasarc label fix

### DIFF
--- a/light_curves/code/heasarc_functions.py
+++ b/light_curves/code/heasarc_functions.py
@@ -104,17 +104,17 @@ def HEASARC_get_lightcurves(coords_list, labels_list, heasarc_cat, max_error_rad
              """
         
         hresult = heasarc_tap.service.run_sync(hquery, uploads={'mytable': coordstab})
-
+        print(f'length of {heasarc_cat[m]} catalog:', len(hresult))
         #  Convert the result to an Astropy Table
         hresulttable = hresult.to_table()
 
         #add results to multiindex_df
         #really just need to mark this spot with a vertical line in the plot, it's not actually a light curve
         #so making up a flux and an error, but the time stamp and mission are the real variables we want to keep
-        df_fermi = pd.DataFrame(dict(flux=np.full(len(hresulttable),0.1), err=np.full(len(hresulttable),0.1), time=hresulttable['time'], objectid = hresulttable['objectid'], band=np.full(len(hresulttable),'Fermi GRB'), label=hresulttable['label'])).set_index(["objectid", "label", "band", "time"])
+        df_heasarc = pd.DataFrame(dict(flux=np.full(len(hresulttable),0.1), err=np.full(len(hresulttable),0.1), time=hresulttable['time'], objectid = hresulttable['objectid'], band=np.full(len(hresulttable),heasarc_cat[m]), label=hresulttable['label'])).set_index(["objectid", "label", "band", "time"])
 
         # Append to existing MultiIndex light curve object
-        df_lc.append(df_fermi)
+        df_lc.append(df_heasarc)
     
     return df_lc
 

--- a/light_curves/multiband_lc.ipynb
+++ b/light_curves/multiband_lc.ipynb
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "scrolled": true,
     "tags": []
@@ -130,19 +130,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Changing Look AGN- Yang et al:  31\n",
-      "SDSS Quasar: 0\n",
-      "after duplicates removal, sample size: 30\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#build up the sample\n",
     "coords =[]\n",
@@ -198,7 +188,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
This tiny PR fixed a bug in the HEASARC functions which had the label for all HEASARC catalogs fixed to a single string.  It now will accurately reflect the catalog name from which the sources was obtained.  At the same time I added some print statements to let us know how many sources were found in the HEASARC catalogs.