### PR TITLE
BUG: Uniformly handle the case where there are no archive matches for coords_list

### DIFF
--- a/light_curves/code_src/gaia_functions.py
+++ b/light_curves/code_src/gaia_functions.py
@@ -44,6 +44,11 @@ def Gaia_get_lightcurve(coords_list, labels_list , verbose):
     
     print(gaia_table.columns)   
     
+    # if none of the objects were found, there's nothing to load and the Gaia_retrieve_EPOCH_PHOTOMETRY fnc
+    # will raise an HTTPError. just return an empty dataframe instead of proceeding
+    if len(gaia_table) == 0:
+        return MultiIndexDFObject()
+
     ## Extract Light curves ===============
     # For each of the objects, request the EPOCH_PHOTOMETRY from the Gaia DataLink Service
 
@@ -58,8 +63,7 @@ def Gaia_get_lightcurve(coords_list, labels_list , verbose):
                                     labels_list=labels_list, gaia_phot = gaia_table,
                                     gaia_epoch_phot=gaia_epoch_phot, verbose=verbose)
 
-    df_lc = MultiIndexDFObject()
-    df_lc.append(df_lc_gaia)
+    df_lc = MultiIndexDFObject(data=df_lc_gaia)
     
     
     return(df_lc)

--- a/light_curves/code_src/ztf_functions.py
+++ b/light_curves/code_src/ztf_functions.py
@@ -49,6 +49,11 @@ def ZTF_get_lightcurve(coords_list, labels_list, nworkers=6, ztf_radius=0.000278
     # use a TAP query to locate which files each object is in
     locations_df = locate_objects(coords_list, labels_list, ztf_radius)
 
+    # if none of the objects were found, there's nothing to load and the load_lightcurves fnc will raise a ValueError
+    # just return an empty dataframe instead of proceeding
+    if len(locations_df.index) == 0:
+        return MultiIndexDFObject()
+
     # the catalog is stored in an AWS S3 bucket. loop over the files and load the light curves
     ztf_df = load_lightcurves(locations_df, nworkers=nworkers)
 

--- a/light_curves/code_src/ztf_functions.py
+++ b/light_curves/code_src/ztf_functions.py
@@ -49,13 +49,13 @@ def ZTF_get_lightcurve(coords_list, labels_list, nworkers=6, ztf_radius=0.000278
     # use a TAP query to locate which files each object is in
     locations_df = locate_objects(coords_list, labels_list, ztf_radius)
 
-    # if none of the objects were found, there's nothing to load and the load_lightcurves fnc will raise a ValueError
-    # just return an empty dataframe instead of proceeding
-    if len(locations_df.index) == 0:
-        return MultiIndexDFObject()
-
     # the catalog is stored in an AWS S3 bucket. loop over the files and load the light curves
     ztf_df = load_lightcurves(locations_df, nworkers=nworkers)
+
+    # if none of the objects were found, the transform_lightcurves function will raise a ValueError
+    # so return an empty dataframe now instead of proceeding
+    if len(ztf_df.index) == 0:
+        return MultiIndexDFObject()
 
     # clean and transform the data into the form needed for a MultiIndexDFObject
     ztf_df = transform_lightcurves(ztf_df)
@@ -175,6 +175,12 @@ def load_lightcurves(locations_df, nworkers=6):
         Dataframe of light curves. Expect one row per oid in locations_df. Each row
         stores a full light curve. Elements in the columns "mag", "hmjd", etc. are arrays.
     """
+    # We need to return an empty dataframe if no matches are found. If the TAP query returned matches 
+    # but none of them are found in the parquet files, this function will naturally return an empty dataframe.
+    # But if the TAP query found no matches, pd.concat (below) will throw a ValueError. Return now to avoid this.
+    if len(locations_df.index) == 0:
+        return pd.DataFrame()
+
     # one group per parquet file
     location_grps = locations_df.groupby(["filtercode", "field", "ccdid", "qid"])
 


### PR DESCRIPTION
Closes #138

Standardizes all `*_get_lightcurve` functions to return an empty dataframe if no matches were found for the objects in `coords_list`. The two functions actually changed here used to throw errors if they didn't find matches. All other functions already return an empty dataframe.