### PR TITLE
MAINT: cleanups for tqdm usage and in icecube code

### DIFF
--- a/light_curves/code_src/icecube_functions.py
+++ b/light_curves/code_src/icecube_functions.py
@@ -2,10 +2,12 @@
 import os
 import zipfile
 
+from urllib.parse import urlparse
+from urllib.request import urlretrieve
+
 import astropy.units as u
 import numpy as np
 import pandas as pd
-import wget
 from astropy.coordinates import SkyCoord
 from astropy.io import ascii
 from astropy.table import Table, vstack
@@ -167,8 +169,8 @@ def icecube_get_catalog(verbose):
     return(EVENTS , event_names)
 
 
-
-def icecube_download_data(verbose):
+def icecube_download_data(url="http://icecube.wisc.edu/data-releases/20210126_PS-IC40-IC86_VII.zip",
+                          path="data", verbose=False):
     '''
     Download and unzipps the IceCube data (approx. 40MB zipped, 120MB unzipped). Directly
     downloaded from the IceCube webpage:
@@ -176,34 +178,39 @@ def icecube_download_data(verbose):
     
     Parameters
     ----------
-    verbose : int
-        How much to talk. 0 = None, 1 = a little bit , 2 = more, 3 = full
+    path : str
+        Path to download data to.
+    verbose : bool
+        Default False. Display extra info and warnings if true.
         
     Returns
     -------
     Unzipped IceCube event tables in the data directory.
     
-    
     '''
-    path = "data"
 
-    ## Download
-    if not os.path.exists(os.path.join(path , "icecube_events.zip")):
+    file_path = os.path.join(path, os.path.basename(urlparse(url).path))
 
-        if verbose > 0: print("Downloading IceCube data to {} | ".format(path) , end=" ")
-        file_url = "http://icecube.wisc.edu/data-releases/20210126_PS-IC40-IC86_VII.zip"
-        wget.download(url = file_url , out = path)
+    if not os.path.exists(file_path):
 
-        ## Unzip
-        if verbose > 0: print("Unzipping IceCube data | ", end=" ")
-        with zipfile.ZipFile(os.path.join(path , "20210126_PS-IC40-IC86_VII.zip"), 'r') as zip_ref:
+        # Download
+        if verbose:
+            print(f"Downloading IceCube data to {file_path}.")
+
+        _ = urlretrieve(url, file_path)
+
+        # Unzip
+        if verbose:
+            print("Unzipping IceCube data.")
+
+        with zipfile.ZipFile(os.path.join(file_path) as zip_ref:
             zip_ref.extractall(path)
 
-        if verbose > 0: print("Done.")
+        if verbose:
+            print("Done.")
 
     else:
-        if verbose > 0: print("Data already downloaded.")
-    
-    return(True)
+        if verbose:
+            print(f"Data is already downloaded, see {path}")
         
     

--- a/light_curves/code_src/sample_lc.py
+++ b/light_curves/code_src/sample_lc.py
@@ -11,9 +11,10 @@ from HCV_functions import HCV_get_lightcurves
 from heasarc_functions import HEASARC_get_lightcurves
 from icecube_functions import icecube_get_lightcurve
 from panstarrs import panstarrs_get_lightcurves
-from sample_selection import (clean_sample, get_green_sample, get_hon_sample, get_lamassa_sample, 
-    get_lopeznavas_sample, get_lyu_sample, get_macleod16_sample, get_macleod19_sample, get_paper_sample, 
-    get_ruan_sample, get_SDSS_sample, get_sheng_sample, get_yang_sample, nonunique_sample, TDE_id2coord)
+from sample_selection import (clean_sample, get_green_sample, get_hon_sample, get_lamassa_sample,
+                              get_lopeznavas_sample, get_lyu_sample, get_macleod16_sample, get_macleod19_sample, get_paper_sample,
+                              get_ruan_sample, get_SDSS_sample, get_sheng_sample, get_yang_sample, nonunique_sample)
+# from tde_functions import TDE_id2coord
 from TESS_Kepler_functions import TESS_Kepler_get_lightcurves
 from WISE_functions import WISE_get_lightcurves
 from ztf_functions import ZTF_get_lightcurve

--- a/light_curves/code_src/sample_selection.py
+++ b/light_curves/code_src/sample_selection.py
@@ -1,6 +1,5 @@
 import astropy.units as u
 import numpy as np
-from alerce.core import Alerce
 from astropy import table
 from astropy.coordinates import SkyCoord
 from astropy.table import Table, join, join_skycoord
@@ -10,32 +9,6 @@ from astroquery.simbad import Simbad
 from astroquery.vizier import Vizier
 
 
-def TDE_id2coord(object_ids,coords,labels,verbose=1):
-    """ To find and append coordinates of objects with only ZTF obj name
-      
-    Parameters
-    ----------
-    object_ids: list of strings
-        eg., [ "ZTF18accqogs", "ZTF19aakyhxi", "ZTF19abyylzv", "ZTF19acyfpno"]
-    coords : list of astropy skycoords
-        the coordinates of the targets for which a user wants light curves
-    labels: list of strings
-        journal articles associated with the target coordinates
-    verbose: int
-        print out debugging info (1) or not(0)
-    """
-    
-    
-    
-    alerce = Alerce()
-    objects = alerce.query_objects(oid=object_ids, format="pandas")
-    tde_coords = [SkyCoord(ra, dec, frame='icrs', unit='deg') for ra, dec in zip(objects['meanra'],objects['meandec'])]
-    tde_labels = ['ZTF-Objname' for ra in objects['meanra']]
-    coords.extend(tde_coords)
-    labels.extend(tde_labels)
-    if verbose:
-        print('number of ztf coords added by Objectname:',len(objects['meanra']))
- 
 #lamassa et al., 2015  1 source
 def get_lamassa_sample(coords, labels, verbose=1):
     """Automatically grabs changing look AGN from LaMassa et al 2015 sample.

--- a/light_curves/code_src/tde_functions.py
+++ b/light_curves/code_src/tde_functions.py
@@ -1,0 +1,27 @@
+from astropy.coordinates import SkyCoord
+
+from alerce.core import Alerce
+
+def TDE_id2coord(object_ids, coords, labels, verbose=1):
+    """ To find and append coordinates of objects with only ZTF obj name
+
+    Parameters
+    ----------
+    object_ids: list of strings
+        eg., [ "ZTF18accqogs", "ZTF19aakyhxi", "ZTF19abyylzv", "ZTF19acyfpno"]
+    coords : list of astropy skycoords
+        the coordinates of the targets for which a user wants light curves
+    labels: list of strings
+        journal articles associated with the target coordinates
+    verbose: int
+        print out debugging info (1) or not(0)
+    """
+
+    alerce = Alerce()
+    objects = alerce.query_objects(oid=object_ids, format="pandas")
+    tde_coords = [SkyCoord(ra, dec, frame='icrs', unit='deg') for ra, dec in zip(objects['meanra'], objects['meandec'])]
+    tde_labels = ['ZTF-Objname' for _ in objects['meanra']]
+    coords.extend(tde_coords)
+    labels.extend(tde_labels)
+    if verbose:
+        print('number of ztf coords added by Objectname:', len(objects['meanra']))

--- a/light_curves/multiband_lc.ipynb
+++ b/light_curves/multiband_lc.ipynb
@@ -41,7 +41,7 @@
     "- `urllib` to handle archive searches with website interface\n",
     "\n",
     "## Authors:\n",
-    "Jessica Krick, Shoubaneh Hemmati, Andreas Faisst, Troy Raen, Brigitta Sipocz, Dave Shupe\n",
+    "Jessica Krick, Shoubaneh Hemmati, Andreas Faisst, Troy Raen, Brigitta Sipőcz, Dave Shupe\n",
     "\n",
     "## Acknowledgements:\n",
     "Suvi Gezari, Antara Basu-zych,Stephanie LaMassa\\\n",

--- a/light_curves/requirements.txt
+++ b/light_curves/requirements.txt
@@ -12,7 +12,6 @@ pandas
 pyvo
 s3fs
 tqdm
-wget
 alerce
 umap-learn[plot]
 git+https://github.com/sevamoo/SOMPY


### PR DESCRIPTION
This PR clears up a couple of smaller issues, and is ready to go in:

 - some bugs in icecube, I suppose it didn't work for me out of the box as I started from new and didn't have a previous reincarnation of the data around
 - removed unnecessary dependency (wget)
 - moved the unused TDE cleanup code out to a new file, so e.g. alerce can be kept as optional dependency (or at least be able to run most of the notebooks without it being installed)
 - moved a lot of hard-wired value out as a kwarg to the functions
 - changed verbose to be a boolean (the typical approach, if more fine tuning is needed, I would suggest to switch to proper logging)
 - fixed tqdm usages and removed manual loopings
 - fixed some style issues, it wasn't comprehensive and only did it for the files being touched in this PR.

