### PR TITLE
IceCube Speedup

### DIFF
--- a/light_curves/code_src/icecube_functions.py
+++ b/light_curves/code_src/icecube_functions.py
@@ -55,13 +55,13 @@ def icecube_get_lightcurve(sample_table, icecube_select_topN=3):
     mysample_skycoords = sample_table['coord']
 
     #Match
-    idx_icecube, idx_mysample, d2d, d3d = icecube_skycoords.search_around_sky(mysample_skycoords, 1*u.deg)
+    idx_mysample, idx_icecube, d2d, d3d = icecube_skycoords.search_around_sky(mysample_skycoords, 1*u.deg)
 
     #need to filter reponse based on position error circles
     #really want d2d to be less than the error circle of icecube = icecube_events["AngErr"] in degrees
-    filter_arr = d2d < icecube_events["AngErr"][idx_mysample]
-    filter_idx_icecube = idx_icecube[filter_arr]
-    filter_idx_mysample = idx_mysample[filter_arr]
+    filter_arr = d2d < icecube_events["AngErr"][idx_icecube]
+    filter_idx_icecube = idx_mysample[filter_arr]
+    filter_idx_mysample = idx_icecubefilter_arr]
     filter_d2d = d2d[filter_arr]
 
     #keep these matches together with objectid and lebal as new entries in the df.

--- a/light_curves/code_src/icecube_functions.py
+++ b/light_curves/code_src/icecube_functions.py
@@ -57,15 +57,15 @@ def icecube_get_lightcurve(sample_table, icecube_select_topN=3):
     #need to filter reponse based on position error circles
     #really want d2d to be less than the error circle of icecube = icecube_events["AngErr"] in degrees
     filter_arr = d2d < icecube_events["AngErr"][idx_icecube]
-    filter_idx_icecube = idx_mysample[filter_arr]
-    filter_idx_mysample = idx_icecubefilter_arr]
+    filter_idx_mysample = idx_mysample[filter_arr]
+    filter_idx_icecube = idx_icecube[filter_arr]
     filter_d2d = d2d[filter_arr]
 
     #keep these matches together with objectid and lebal as new entries in the df.
-    obid_match = sample_table['objectid'][filter_idx_icecube]
-    label_match = sample_table['label'][filter_idx_icecube]
-    time_icecube= icecube_events['mjd'][filter_idx_mysample]
-    flux_icecube = icecube_events['energy_logGeV'][filter_idx_mysample]
+    obid_match = sample_table['objectid'][filter_idx_mysample]
+    label_match = sample_table['label'][filter_idx_mysample]
+    time_icecube= icecube_events['mjd'][filter_idx_icecube]
+    flux_icecube = icecube_events['energy_logGeV'][filter_idx_icecube]
 
     #save the icecube info in correct format for the rest of the data
     icecube_df = pd.DataFrame({'flux': flux_icecube, 
@@ -82,7 +82,7 @@ def icecube_get_lightcurve(sample_table, icecube_select_topN=3):
     filter_icecube_df = icecube_df.groupby('objectid').head(icecube_select_topN).reset_index(drop=True)
 
     #put the index in to match with df_lc
-    filter_icecube_df.set_index(["objectid", "label", "band", "time"])
+    filter_icecube_df.set_index(["objectid", "label", "band", "time"], inplace = True)
     
     return (filter_icecube_df)
 

--- a/light_curves/code_src/icecube_functions.py
+++ b/light_curves/code_src/icecube_functions.py
@@ -45,9 +45,6 @@ def icecube_get_lightcurve(sample_table, icecube_select_topN=3):
     # Each file has a list of events with their energy, time, and approximate direction.
     icecube_events, _ = icecube_get_catalog(verbose=False)
 
-    # sort by Neutrino energy that way it is easier to get the top N events.
-    icecube_events.sort(keys="energy_logGeV", reverse=True)
-
     # create SkyCoord objects from icecube event coordinates
     icecube_skycoords = SkyCoord(icecube_events["ra"], icecube_events["dec"], unit="deg", frame='icrs')
 
@@ -78,6 +75,9 @@ def icecube_get_lightcurve(sample_table, icecube_select_topN=3):
                                'label': label_match, 
                                'band': "IceCube"})
 
+    # sort by Neutrino energy that way it is easier to get the top N events.
+    icecube_df = icecube_df.sort_values(['objectid', 'flux'], ascending=[True, False])
+    
     #now can use a groupby to only keep the top N (by GeV flux) icecube matches for each object
     filter_icecube_df = icecube_df.groupby('objectid').head(icecube_select_topN).reset_index(drop=True)
 

--- a/light_curves/light_curve_generator.md
+++ b/light_curves/light_curve_generator.md
@@ -119,7 +119,7 @@ get_yang_sample(coords, labels)   #2018ApJ...862..109Y
 #a balance between speed of running the light curves and whatever 
 #the ML algorithms would like to have
 
-#num_normal_QSO = 50
+#num_normal_QSO = 5000
 #get_SDSS_sample(coords, labels, num_normal_QSO)
 
 # remove duplicates and attach an objectid to the coords
@@ -296,7 +296,6 @@ The IceCube catalog contains Neutrino detections with associated energy and time
 This time series (time vs. neutrino energy) information is similar to photometry. We choose to storing time and energy in our data structure, leaving error = 0. What is __not__ stored in this format is the distance or angular uncertainty of the event direction.
 
 ```{code-cell} ipython3
-%%time
 df_lc_icecube = icecube_get_lightcurve(sample_table ,
                                    icecube_select_topN = 3)
 

--- a/light_curves/light_curve_generator.md
+++ b/light_curves/light_curve_generator.md
@@ -54,7 +54,6 @@ Jessica Krick, Shoubaneh Hemmati, Andreas Faisst, Troy Raen, Brigitta Sipőcz, D
 Suvi Gezari, Antara Basu-zych,Stephanie LaMassa\
 MAST, HEASARC, & IRSA Fornax teams
 
-
 ```{code-cell} ipython3
 #ensure all dependencies are installed
 !pip install -r requirements.txt
@@ -87,7 +86,7 @@ from TESS_Kepler_functions import TESS_Kepler_get_lightcurves
 # Note: WISE and ZTF data are temporarily located in a non-public AWS S3 bucket. It is automatically
 # available from the Fornax SMCE, but will require user credentials for access outside the SMCE.
 from WISE_functions import WISE_get_lightcurves
-from ztf_functions import ZTF_get_lightcurve
+#from ztf_functions import ZTF_get_lightcurve
 ```
 
 ## 1. Define the Sample
@@ -104,15 +103,15 @@ labels = []
 
 #choose your own adventure:
 
-#get_lamassa_sample(coords, labels)  #2015ApJ...800..144L
-#get_macleod16_sample(coords, labels) #2016MNRAS.457..389M
-#get_ruan_sample(coords, labels) #2016ApJ...826..188R
-#get_macleod19_sample(coords, labels)  #2019ApJ...874....8M
-#get_sheng_sample(coords, labels)  #2020ApJ...889...46S
-#get_green_sample(coords, labels)  #2022ApJ...933..180G
-#get_lyu_sample(coords, labels)  #z32022ApJ...927..227L
-#get_lopeznavas_sample(coords, labels)  #2022MNRAS.513L..57L
-#get_hon_sample(coords, labels)  #2022MNRAS.511...54H
+get_lamassa_sample(coords, labels)  #2015ApJ...800..144L
+get_macleod16_sample(coords, labels) #2016MNRAS.457..389M
+get_ruan_sample(coords, labels) #2016ApJ...826..188R
+get_macleod19_sample(coords, labels)  #2019ApJ...874....8M
+get_sheng_sample(coords, labels)  #2020ApJ...889...46S
+get_green_sample(coords, labels)  #2022ApJ...933..180G
+get_lyu_sample(coords, labels)  #z32022ApJ...927..227L
+get_lopeznavas_sample(coords, labels)  #2022MNRAS.513L..57L
+get_hon_sample(coords, labels)  #2022MNRAS.511...54H
 get_yang_sample(coords, labels)   #2018ApJ...862..109Y
 
 #now get some "normal" QSOs for use in the classifier
@@ -125,7 +124,6 @@ get_yang_sample(coords, labels)   #2018ApJ...862..109Y
 
 # remove duplicates and attach an objectid to the coords
 sample_table = clean_sample(coords, labels)
-
 ```
 
 ### 1.1 Build your own Sample
@@ -135,7 +133,7 @@ To build your own sample, you can follow the examples of functions above to grab
 or
 
 You can use [astropy's read](https://docs.astropy.org/en/stable/io/ascii/read.html) function to read in an input table
-and then convert that table into a list of [skycoords](https://docs.astropy.org/en/stable/api/astropy.coordinates.SkyCoord.html) 
+and then convert that table into a list of [skycoords](https://docs.astropy.org/en/stable/api/astropy.coordinates.SkyCoord.html)
 
 +++
 
@@ -238,14 +236,12 @@ df_lc.append(df_lc_panstarrs)
      2. it is only accessible with casjobs, not through python notebooks.  
      3. magnitude range (g, r, i) < 19mag makes it not relevant for this use case
  
-One path forward if this catalog becomes scientifically interesting is to put in a MAST helpdesk ticket to see if 1) they do have the light curves, and 2) they could switch the catalog to a searchable with python version.  There are some ways of [accessing casjobs with python](<https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/HSC/HCV_CASJOBS/HCV_casjobs_demo.ipynb), but not this particular catalog.  
- 
+One path forward if this catalog becomes scientifically interesting is to put in a MAST helpdesk ticket to see if 1) they do have the light curves, and 2) they could switch the catalog to a searchable with python version.  There are some ways of [accessing casjobs with python](<https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/HSC/HCV_CASJOBS/HCV_casjobs_demo.ipynb), but not this particular catalog.
 
 +++
 
 ### 2.6 MAST: TESS, Kepler and K2
  - use [`lightKurve`](https://docs.lightkurve.org/index.html) to search all 3 missions and download light curves
- 
 
 ```{code-cell} ipython3
 #go get the lightcurves using lightkurve
@@ -273,7 +269,7 @@ df_lc.append(df_lc_HCV)
 
 +++
 
-### 3.1 Gaia 
+### 3.1 Gaia
 
 ```{code-cell} ipython3
 gaiastarttime = time.time()
@@ -289,7 +285,6 @@ print('gaia search took:', time.time() - gaiastarttime, 's')
 - Has a [website](https://asas-sn.osu.edu/photometry) that can be manually searched; but no API which would allow automatic searches from within this notebook
 - Magnitude range of this survey is not consistent with the magnitude range of our CLAGN.  If this catalog becomes scientifically interesting, one path forward would be to ask ASAS-SN team about implementing an API
 
-
 +++
 
 ### 3.3 Icecube Neutrinos
@@ -298,12 +293,12 @@ There are several [catalogs](https://icecube.wisc.edu/data-releases/2021/01/all-
 all the yearly catalogs.
 The IceCube catalog contains Neutrino detections with associated energy and time and approximate direction (which is uncertain by half-degree scales....). Usually, for active events only one or two Neutrinos are detected, which makes matching quite different compared to "photons". For our purpose, we will list the top 3 events in energy that are within a given distance to the target.
 
-This time series (time vs. neutrino energy) information is similar to photometry. We choose to storing time and energy in our data structure, leaving error = 0. What is __not__ stored in this format is the distance or angular uncertainty of the event direction. 
+This time series (time vs. neutrino energy) information is similar to photometry. We choose to storing time and energy in our data structure, leaving error = 0. What is __not__ stored in this format is the distance or angular uncertainty of the event direction.
 
 ```{code-cell} ipython3
-df_lc_icecube = icecube_get_lightcurve(coords_list , labels_list ,
-                                   icecube_select_topN = 3,
-                                   verbose = 1)
+%%time
+df_lc_icecube = icecube_get_lightcurve(sample_table ,
+                                   icecube_select_topN = 3)
 
 #add the resulting dataframe to all other archives
 df_lc.append(df_lc_icecube)
@@ -364,13 +359,13 @@ with mp.Pool(processes=n_workers) as pool:
         Gaia_get_lightcurve, (sample_table, 1/3600., 0), callback=callback
     )
     pool.apply_async(
-        HEASARC_get_lightcurves, (coords_list, labels_list, heasarc_cat, error_radius), callback=callback
+        HEASARC_get_lightcurves, (sample_table, heasarc_cat, error_radius), callback=callback
     )
     pool.apply_async(
         HCV_get_lightcurves, (coords_list, labels_list, hcv_radius), callback=callback
     )
     pool.apply_async(
-        icecube_get_lightcurve, (coords_list, labels_list, 3, 1), callback=callback
+        icecube_get_lightcurve, (sample_table , 3), callback=callback
     )
     pool.apply_async(
         panstarrs_get_lightcurves, (coords_list, labels_list, panstarrs_radius), callback=callback
@@ -379,7 +374,7 @@ with mp.Pool(processes=n_workers) as pool:
         TESS_Kepler_get_lightcurves, (coords_list, labels_list, lk_radius), callback=callback
     )
     pool.apply_async(
-        WISE_get_lightcurves, (coords_list, labels_list, wise_radius, bandlist), callback=callback
+        WISE_get_lightcurves, (sample_table,  wise_radius, bandlist), callback=callback
     )
     pool.apply_async(
         ZTF_get_lightcurve, (coords_list, labels_list, ztf_nworkers), callback=callback

--- a/light_curves/light_curve_generator.md
+++ b/light_curves/light_curve_generator.md
@@ -86,7 +86,7 @@ from TESS_Kepler_functions import TESS_Kepler_get_lightcurves
 # Note: WISE and ZTF data are temporarily located in a non-public AWS S3 bucket. It is automatically
 # available from the Fornax SMCE, but will require user credentials for access outside the SMCE.
 from WISE_functions import WISE_get_lightcurves
-#from ztf_functions import ZTF_get_lightcurve
+from ztf_functions import ZTF_get_lightcurve
 ```
 
 ## 1. Define the Sample
@@ -103,15 +103,15 @@ labels = []
 
 #choose your own adventure:
 
-get_lamassa_sample(coords, labels)  #2015ApJ...800..144L
-get_macleod16_sample(coords, labels) #2016MNRAS.457..389M
-get_ruan_sample(coords, labels) #2016ApJ...826..188R
-get_macleod19_sample(coords, labels)  #2019ApJ...874....8M
-get_sheng_sample(coords, labels)  #2020ApJ...889...46S
-get_green_sample(coords, labels)  #2022ApJ...933..180G
-get_lyu_sample(coords, labels)  #z32022ApJ...927..227L
-get_lopeznavas_sample(coords, labels)  #2022MNRAS.513L..57L
-get_hon_sample(coords, labels)  #2022MNRAS.511...54H
+#get_lamassa_sample(coords, labels)  #2015ApJ...800..144L
+#get_macleod16_sample(coords, labels) #2016MNRAS.457..389M
+#get_ruan_sample(coords, labels) #2016ApJ...826..188R
+#get_macleod19_sample(coords, labels)  #2019ApJ...874....8M
+#get_sheng_sample(coords, labels)  #2020ApJ...889...46S
+#get_green_sample(coords, labels)  #2022ApJ...933..180G
+#get_lyu_sample(coords, labels)  #z32022ApJ...927..227L
+#get_lopeznavas_sample(coords, labels)  #2022MNRAS.513L..57L
+#get_hon_sample(coords, labels)  #2022MNRAS.511...54H
 get_yang_sample(coords, labels)   #2018ApJ...862..109Y
 
 #now get some "normal" QSOs for use in the classifier


### PR DESCRIPTION
I updated icecube_get_lightcurve to use astropy `search_around_sky` instead of a for loop over all objects.  This should provide a large increase in speed of the ice cube function.  Currently I can't do a good scale test on this because the SDSS function isn't working, but this really should be a speedup, so I am pushing the changes without the scale test.

I would appreciate if someone could check the filtering that I did after the match, to make sure the code does what I wanted it to.  My intent was to have it match all sources within the error radius of of IceCube, then later filter that down to the top three in energy for each input source.  