### PR TITLE
convert all remaining functions to use sample_table instead of coords_list and labels_list

### DIFF
--- a/light_curves/code_src/HCV_functions.py
+++ b/light_curves/code_src/HCV_functions.py
@@ -209,15 +209,13 @@ def checklegal_hcv(table,release,magtype):
             raise ValueError("Bad value for magtype (must be one of {})".format(
                 ", ".join(magtypelist)))
             
-def HCV_get_lightcurves(coords_list, labels_list, radius):
+def HCV_get_lightcurves(sample_table, radius):
     """Searches Hubble Catalog of variables for light curves from a list of input coordinates
     
     Parameters
     ----------
-    coords_list : list of astropy skycoords
-        the coordinates of the targets for which a user wants light curves
-    labels_list: list of strings
-        journal articles associated with the target coordinates
+    sample_table:  `~astropy.table.Table`
+        Table with the coordinates and journal reference labels of the sources
     radius : float
         search radius, how far from the source should the archives return results
 
@@ -228,13 +226,16 @@ def HCV_get_lightcurves(coords_list, labels_list, radius):
     """
 
     df_lc = MultiIndexDFObject()
-    for objectid, coord in coords_list:
+    
 
-        #doesn't take SkyCoord, convert to floats
-        ra = coord.ra.deg
-        dec = coord.dec.deg
-        lab = labels_list[objectid]
+    
+    for row in sample_table:
 
+        ra = row['coord'].ra.deg
+        dec = row['coord'].dec.deg
+        lab = row['label']
+        objectid = row['objectid']
+       
         #IC 1613 from the demo for testing
         #ra = 16.19913
         #dec = 2.11778

--- a/light_curves/code_src/TESS_Kepler_functions.py
+++ b/light_curves/code_src/TESS_Kepler_functions.py
@@ -34,7 +34,7 @@ def clean_filternames(search_result, numlc):
         filtername = 'K2'
     return(filtername)
 
-def TESS_Kepler_get_lightcurves(coords_list, labels_list, radius):
+def TESS_Kepler_get_lightcurves(sample_table, radius):
     """Searches TESS, Kepler, and K2 for light curves from a list of input coordinates
     
     Parameters
@@ -53,6 +53,11 @@ def TESS_Kepler_get_lightcurves(coords_list, labels_list, radius):
     """
     
     df_lc = MultiIndexDFObject()
+    
+    #first convert sample_table to coords_list, labels_list
+    coords_list = [(row['objectid'] - 1, row['coord']) for row in sample_table]
+    labels_list = [row['label'] for row in sample_table]
+    
     #for all objects
     for objectid, coord in tqdm(coords_list):
     #for testing, this has 79 light curves between the three missions.

--- a/light_curves/code_src/TESS_Kepler_functions.py
+++ b/light_curves/code_src/TESS_Kepler_functions.py
@@ -55,7 +55,7 @@ def TESS_Kepler_get_lightcurves(sample_table, radius):
     df_lc = MultiIndexDFObject()
     
     #first convert sample_table to coords_list, labels_list
-    coords_list = [(row['objectid'] - 1, row['coord']) for row in sample_table]
+    coords_list = [(row['objectid'], row['coord']) for row in sample_table]
     labels_list = [row['label'] for row in sample_table]
     
     #for all objects

--- a/light_curves/code_src/gaia_functions.py
+++ b/light_curves/code_src/gaia_functions.py
@@ -9,7 +9,6 @@ from astropy.time import Time
 from astroquery.gaia import Gaia
 
 from data_structures import MultiIndexDFObject
-from sample_selection import make_coordsTable
 
 
 def Gaia_get_lightcurve(sample_table, search_radius, verbose):
@@ -33,7 +32,7 @@ def Gaia_get_lightcurve(sample_table, search_radius, verbose):
     '''
 
     # Retrieve Gaia table with Source IDs ==============
-    gaia_table = Gaia_retrieve_catalog(sample_table , labels_list,
+    gaia_table = Gaia_retrieve_catalog(sample_table , 
                                          search_radius = search_radius,
                                          verbose = verbose
                                          )

--- a/light_curves/code_src/gaia_functions.py
+++ b/light_curves/code_src/gaia_functions.py
@@ -99,7 +99,7 @@ def Gaia_retrieve_catalog(source_table , search_radius, verbose):
     results = j.get_results()
     
     if verbose : print("\nSearch completed in {:.2f} seconds".format((time.time()-t1) ) )
-    if verbose : print("Number of objects matched: {} out of {}.".format(len(results),len(coords_list) ) )
+    if verbose : print("Number of objects matched: {} out of {}.".format(len(results),len(sample_table) ) )
 
     return results
 

--- a/light_curves/code_src/icecube_functions.py
+++ b/light_curves/code_src/icecube_functions.py
@@ -16,7 +16,7 @@ from tqdm import tqdm
 from data_structures import MultiIndexDFObject
 
 
-def icecube_get_lightcurve(sample_table, icecube_select_topN=3):
+def Icecube_get_lightcurve(sample_table, icecube_select_topN=3):
     '''
     Extracts IceCube Neutrino events for a given source position and saves it into a lightcurve
     Pandas MultiIndex object.

--- a/light_curves/code_src/panstarrs.py
+++ b/light_curves/code_src/panstarrs.py
@@ -230,7 +230,7 @@ def search_lightcurve(objid):
 
 
 #Do a panstarrs search
-def panstarrs_get_lightcurves(coords_list, labels_list, radius):
+def Panstarrs_get_lightcurves(sample_table, radius):
     """Searches panstarrs for light curves from a list of input coordinates
     
     Parameters
@@ -249,6 +249,11 @@ def panstarrs_get_lightcurves(coords_list, labels_list, radius):
     """
         
     df_lc = MultiIndexDFObject()
+    
+    #first convert sample_table to coords_list, labels_list
+    coords_list = [(row['objectid'] - 1, row['coord']) for row in sample_table]
+    labels_list = [row['label'] for row in sample_table]
+    
     #for all objects in our catalog
     for objectid, coord in tqdm(coords_list):
         #doesn't take SkyCoord, convert to floats

--- a/light_curves/code_src/panstarrs.py
+++ b/light_curves/code_src/panstarrs.py
@@ -251,7 +251,7 @@ def Panstarrs_get_lightcurves(sample_table, radius):
     df_lc = MultiIndexDFObject()
     
     #first convert sample_table to coords_list, labels_list
-    coords_list = [(row['objectid'] - 1, row['coord']) for row in sample_table]
+    coords_list = [(row['objectid'], row['coord']) for row in sample_table]
     labels_list = [row['label'] for row in sample_table]
     
     #for all objects in our catalog

--- a/light_curves/code_src/plot_functions.py
+++ b/light_curves/code_src/plot_functions.py
@@ -34,14 +34,14 @@ def setup_text_plots():
     mpl.rcParams['ytick.right'] = True
     mpl.rcParams['hatch.linewidth'] = 1
 
-def create_figures(coords_list , df_lc, show_nbr_figures, save_output):
+def create_figures(sample_table , df_lc, show_nbr_figures, save_output):
     '''
-    Creates figures of the lightcurves for each source in the coordinate list.
+    Creates figures of the lightcurves for each source in the sample_table.
     
     Parameters
     ----------
-    coords_list : list of ID and Astropy SkyCoord objects typles
-        List of (id,coordinates) tuples of the sources.
+    sample_table : `~astropy.table.Table`
+        Table with the coordinates, objectid's and journal reference labels of the sources
         
     df_lc : lightcurve object
         Lightcurve objects from which to create the lightcurve figures.
@@ -63,7 +63,7 @@ def create_figures(coords_list , df_lc, show_nbr_figures, save_output):
     -----
     By default, if save_output is True, figures are
     made and saved for *all* sources. If that is too much, the user can create a selection
-    in `coords_list' of which sources they like to plot (and save).
+    from the sample of which sources they like to plot (and save).
     
     '''
     
@@ -72,8 +72,8 @@ def create_figures(coords_list , df_lc, show_nbr_figures, save_output):
         return(False)
     
     cc = 0
-    for objectid, coord in tqdm(coords_list):
-        
+    for row in sample_table:
+        objectid = row['objectid']
         cc += 1 # counter (1-indexed)
         
         ## Set up =================

--- a/light_curves/code_src/sample_selection.py
+++ b/light_curves/code_src/sample_selection.py
@@ -445,5 +445,3 @@ def nonunique_sample(skycoordslist, labels, verbose=1):
     return coords_list, labels_list
 
 
-def make_coordsTable():
-    pass

--- a/light_curves/light_curve_generator.md
+++ b/light_curves/light_curve_generator.md
@@ -6,9 +6,9 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.15.2
 kernelspec:
-  display_name: science_demo
+  display_name: Python 3 (ipykernel)
   language: python
-  name: conda-env-science_demo-py
+  name: python3
 ---
 
 # Make multiwavelength light curves using archival data
@@ -186,7 +186,7 @@ df_lc.append(df_lc_fermi)
 
 ### 2.2 IRSA: ZTF
 
-```{raw-cell}
+```{code-cell} ipython3
 # use the nworkers arg to control the amount of parallelization in the data loading step
 df_lc_ZTF = ZTF_get_lightcurve(coords_list, labels_list, nworkers=6)
 


### PR DESCRIPTION
I think I touched every file except ztf_functions.py since that is in PR #170 

I did:
- for panstarrs and TESS/Kepler/K2 functions I took the easy route of just moving the workaround of converting the table back into coords_list and labels_list into those functions and not having it in the main notebook.  My thought there is that these functions need to change in the future anyway in order to access those archives at scale, so for now we will just put a band-aid on those functions so they still work for a small sample, but not think too much about a bigger fix for now.  In other words, it is not worth spending time on these functions now, when we will have to completely re-work them later.  I just made them functional.
- changed HCV to use sample_table
- changed plotting function to be sample_table
- consistent capitalization of function names
- removed now empty function make_coordsTable from sample_selection.py that got replaced in the gaia and ZTF functions by something else.  I did not remove the import line in the ztf_functions.py because I am trying not to touch that file so it won't conflict with Troy's PR.
- Following a discussion on slack, I chose to leave the sample_table as an astropy table both because it was easier at this point with half the functions already using it, and because it is good to have some representation of skycoords in the demo.  I'm not sure it is worth the work to switch now to pandas, but if someone feels strongly that the demo notebook is too inconsistent with different data types, then we can talk about changing it.  


This now means that the light curve notebook is once again fully functional from start to finish in conjunction with PR #170 

