### PR TITLE
Clean up light curves code

### DIFF
--- a/light_curves/code_src/WISE_functions.py
+++ b/light_curves/code_src/WISE_functions.py
@@ -146,7 +146,7 @@ def transform_lightcurves(wise_df):
     Parameters
     ----------
     wise_df : pd.DataFrame
-        dataframe of light curves as returned by `load_data`.
+        dataframe of light curves as returned by `load_lightcurves`.
 
     Returns
     -------

--- a/light_curves/code_src/WISE_functions.py
+++ b/light_curves/code_src/WISE_functions.py
@@ -48,7 +48,7 @@ def WISE_get_lightcurves(sample_table, radius=1.0 * u.arcsec, bandlist=["W1", "W
 
 
 def locate_objects(sample_table, radius):
-    """Locate the partitions (HEALPix order 5 pixels) each coords_list object is in.
+    """Locate the partitions (HEALPix order 5 pixels) each sample_table object is in.
 
     Parameters
     ----------

--- a/light_curves/code_src/WISE_functions.py
+++ b/light_curves/code_src/WISE_functions.py
@@ -20,7 +20,7 @@ def WISE_get_lightcurves(sample_table, radius=1.0 * u.arcsec, bandlist=["W1", "W
 
     Parameters
     ----------
-    source_table : `~astropy.table.Table`
+    sample_table : `~astropy.table.Table`
         Table with the coordinates and journal reference labels of the sources
     radius : astropy Quantity
         radius for the cone search to determine whether a particular detection is associated with an object
@@ -47,12 +47,12 @@ def WISE_get_lightcurves(sample_table, radius=1.0 * u.arcsec, bandlist=["W1", "W
     return MultiIndexDFObject(data=wise_df.set_index(indexes)[columns])
 
 
-def locate_objects(source_table, radius):
+def locate_objects(sample_table, radius):
     """Locate the partitions (HEALPix order 5 pixels) each coords_list object is in.
 
     Parameters
     ----------
-    source_table : `~astropy.table.Table`
+    sample_table : `~astropy.table.Table`
         Table with the coordinates and journal reference labels of the sources
     radius : astropy Quantity
         radius for the cone search to determine which pixels overlap with each object
@@ -67,10 +67,10 @@ def locate_objects(source_table, radius):
     healpix_pixel = [hpgeom.query_circle(a=row['coord'].ra.deg, b=row['coord'].dec.deg,
                                          radius=radius.to(u.deg).value,
                                          nside=hpgeom.order_to_nside(K), nest=True, inclusive=True)
-                     for row in source_table]
+                     for row in sample_table]
 
     # TODO: simplify, e.g. avoid switching between Table and DF
-    locations_table = source_table.copy()
+    locations_table = sample_table.copy()
     locations_table['pixel'] = healpix_pixel
 
     locations = locations_table.to_pandas()

--- a/light_curves/code_src/data_structures.py
+++ b/light_curves/code_src/data_structures.py
@@ -1,6 +1,4 @@
 #setup to save the light curves in a data structure
-import pickle
-
 import pandas as pd
 from astropy.table import vstack
 from astropy.timeseries import TimeSeries
@@ -67,28 +65,6 @@ class MultiIndexDFObject:
         
         # if we get here, both new_data and self.data contain data, so concat
         self.data = pd.concat([self.data, new_data])
-            
-    def pickle(self,x):
-        """ Save the multiindex data frame to a pickle file
-        
-        Parameters
-        ----------
-        x : string or path
-            where to save the pickle file
-        """
-        
-        self.data.to_pickle(x)  
-        
-    def load_pickle(self,x):
-        """ Load the multiindex data frame from a pickle file
-        
-        Parameters
-        ----------
-        x : string or path
-            path of the pickle file to be loaded
-        """
-        with open(x , "rb") as f:
-            self.data = pickle.load(f)
             
     def remove(self,x):
         """ Drop a light curve from the dataframe

--- a/light_curves/code_src/data_structures.py
+++ b/light_curves/code_src/data_structures.py
@@ -50,11 +50,23 @@ class MultiIndexDFObject:
             contains columns [flux, fluxerr] and multi-index [objectid, label, band, time]
         """
         if isinstance(x, self.__class__):
-            # x is a MultiIndexDFObject. extract the DataFrame and concat
-            self.data = pd.concat([self.data, x.data])
+            # x is a MultiIndexDFObject. extract the DataFrame
+            new_data = x.data
         else:
-            # assume x is a pd.DataFrame and concat
-            self.data = pd.concat([self.data, x])
+            # assume x is a pd.DataFrame
+            new_data = x
+        
+        # if either new_data or self.data is empty we should not try to concat
+        if new_data.empty:
+            # leave self.data as is
+            return
+        if self.data.empty:
+            # replace self.data with new_data
+            self.data = new_data
+            return
+        
+        # if we get here, both new_data and self.data contain data, so concat
+        self.data = pd.concat([self.data, new_data])
             
     def pickle(self,x):
         """ Save the multiindex data frame to a pickle file

--- a/light_curves/code_src/gaia_functions.py
+++ b/light_curves/code_src/gaia_functions.py
@@ -1,11 +1,7 @@
 import time
 
-import astropy.units as u
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from astropy.table import Table, hstack
-from astropy.time import Time
 from astroquery.gaia import Gaia
 
 from data_structures import MultiIndexDFObject

--- a/light_curves/code_src/gaia_functions.py
+++ b/light_curves/code_src/gaia_functions.py
@@ -51,7 +51,7 @@ def Gaia_get_lightcurve(sample_table, search_radius, verbose):
 
     return df_lc
 
-def Gaia_retrieve_catalog(source_table , search_radius, verbose):
+def Gaia_retrieve_catalog(sample_table , search_radius, verbose):
     '''
     Retrieves the photometry table for a list of sources.
     
@@ -76,9 +76,9 @@ def Gaia_retrieve_catalog(source_table , search_radius, verbose):
     
     #first make an astropy table from our master list of coordinates
     # as input to the pyvo TAP query 
-    upload_table = source_table['objectid', 'label']
-    upload_table['ra'] = source_table['coord'].ra.deg
-    upload_table['dec'] = source_table['coord'].dec.deg
+    upload_table = sample_table['objectid', 'label']
+    upload_table['ra'] = sample_table['coord'].ra.deg
+    upload_table['dec'] = sample_table['coord'].dec.deg
 
     #this query is too slow without gaia.random_index.  
     #Gaia helpdesk is aware of this bug somewhere on their end

--- a/light_curves/code_src/heasarc_functions.py
+++ b/light_curves/code_src/heasarc_functions.py
@@ -53,12 +53,12 @@ def make_hist_error_radii(missioncat):
     return heasarcresulttable
 
 
-def HEASARC_get_lightcurves(source_table, heasarc_cat, max_error_radius):
+def HEASARC_get_lightcurves(sample_table, heasarc_cat, max_error_radius):
     """Searches HEASARC archive for light curves from a specific list of mission catalogs
 
     Parameters
     ----------
-    source_table : `~astropy.table.Table`
+    sample_table : `~astropy.table.Table`
         Table with the coordinates and journal reference labels of the sources
     heasarc_cat : str list
         list of catalogs within HEASARC to search for light curves.  Must be one of the catalogs listed here:
@@ -77,11 +77,11 @@ def HEASARC_get_lightcurves(source_table, heasarc_cat, max_error_radius):
         the main data structure to store all light curves
     """
 
-    # Prepping source_table with float R.A. and DEC column instead of SkyCoord mixin for TAP upload
+    # Prepping sample_table with float R.A. and DEC column instead of SkyCoord mixin for TAP upload
 
-    upload_table = source_table['objectid', 'label']
-    upload_table['ra'] = source_table['coord'].ra.deg
-    upload_table['dec'] = source_table['coord'].dec.deg
+    upload_table = sample_table['objectid', 'label']
+    upload_table['ra'] = sample_table['coord'].ra.deg
+    upload_table['dec'] = sample_table['coord'].dec.deg
 
     #setup to store the data
     df_lc = MultiIndexDFObject()

--- a/light_curves/code_src/icecube_functions.py
+++ b/light_curves/code_src/icecube_functions.py
@@ -82,7 +82,7 @@ def Icecube_get_lightcurve(sample_table, icecube_select_topN=3):
     #put the index in to match with df_lc
     filter_icecube_df.set_index(["objectid", "label", "band", "time"], inplace = True)
     
-    return (filter_icecube_df)
+    return (MultiIndexDFObject(data=filter_icecube_df))
 
 
 def icecube_get_catalog(path="data", verbose=False):

--- a/light_curves/code_src/icecube_functions.py
+++ b/light_curves/code_src/icecube_functions.py
@@ -1,7 +1,6 @@
 # Functions related to IceCube matching
 import os
 import zipfile
-
 from urllib.parse import urlparse
 from urllib.request import urlretrieve
 
@@ -11,7 +10,6 @@ import pandas as pd
 from astropy.coordinates import SkyCoord
 from astropy.io import ascii
 from astropy.table import Table, vstack
-from tqdm import tqdm
 
 from data_structures import MultiIndexDFObject
 

--- a/light_curves/code_src/panstarrs.py
+++ b/light_curves/code_src/panstarrs.py
@@ -235,10 +235,8 @@ def Panstarrs_get_lightcurves(sample_table, radius):
     
     Parameters
     ----------
-    coords_list : list of astropy skycoords
-        the coordinates of the targets for which a user wants light curves
-    labels_list: list of strings
-        journal articles associated with the target coordinates
+    sample_table : `~astropy.table.Table`
+        Table with the coordinates and journal reference labels of the sources
     radius : float
         search radius, how far from the source should the archives return results
 
@@ -250,16 +248,13 @@ def Panstarrs_get_lightcurves(sample_table, radius):
         
     df_lc = MultiIndexDFObject()
     
-    #first convert sample_table to coords_list, labels_list
-    coords_list = [(row['objectid'], row['coord']) for row in sample_table]
-    labels_list = [row['label'] for row in sample_table]
-    
     #for all objects in our catalog
-    for objectid, coord in tqdm(coords_list):
+    for row in tqdm(sample_table):
         #doesn't take SkyCoord, convert to floats
-        ra = coord.ra.deg
-        dec = coord.dec.deg
-        lab = labels_list[objectid]
+        ra = row["coord"].ra.deg
+        dec = row["coord"].dec.deg
+        lab = row["label"]
+        objectid = row["objectid"]
 
         #sometimes there isn't actually a light curve for the target???
         try:

--- a/light_curves/code_src/plot_functions.py
+++ b/light_curves/code_src/plot_functions.py
@@ -5,7 +5,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 from astropy.table import Table
 from scipy import stats
-from tqdm import tqdm
 
 
 def setup_text_plots():

--- a/light_curves/code_src/sample_selection.py
+++ b/light_curves/code_src/sample_selection.py
@@ -1,9 +1,7 @@
+import astropy.units as u
 import numpy as np
-
 from astropy.coordinates import SkyCoord
 from astropy.table import Table, join, join_skycoord, unique
-import astropy.units as u
-
 from astroquery.ipac.ned import Ned
 from astroquery.sdss import SDSS
 from astroquery.simbad import Simbad

--- a/light_curves/code_src/tde_functions.py
+++ b/light_curves/code_src/tde_functions.py
@@ -1,6 +1,6 @@
+from alerce.core import Alerce
 from astropy.coordinates import SkyCoord
 
-from alerce.core import Alerce
 
 def TDE_id2coord(object_ids, coords, labels, verbose=1):
     """ To find and append coordinates of objects with only ZTF obj name

--- a/light_curves/code_src/ztf_functions.py
+++ b/light_curves/code_src/ztf_functions.py
@@ -8,7 +8,7 @@ import s3fs
 import tqdm
 
 from data_structures import MultiIndexDFObject
-from sample_selection import make_coordsTable
+
 
 # the catalog is stored in an AWS S3 bucket
 DATARELEASE = "dr18"


### PR DESCRIPTION
Included changes:

- Remove unused imports. Sort remaining.
- Rename `source_table` -> `sample_table`. When `coords_list` was converted to a Table, most of those variables were named `sample_table` but a few were named `source_table`. This makes them all named `sample_table` for consistency.
- Make IceCube return a `MultiIndexDFObject` for consistency with other functions.
- Remove `coords_list` and `labels_list` from TESS_Kepler_functions.py and panstarrs.py. Since the `objectid`s are now 1-based, they can no longer be used directly as an index into `labels_list`. This caused a bug in both files. Rather than patching in the correct indexes, I just updated those functions to use `sample_table`.
- Remove all references to `coords_list` and `labels_list` from docstrings and code comments in the archive modules.
- Fix `MultiIndexDFObject.append` to avoid the warning about concatenating empty dataframes.
- Remove `pickle` methods. Closes #155.

I've started a list in #177 of other things we might want to clean up in the future.

Note that `HEASARC_get_lightcurves` is throwing an error for me on both the SMCE and ISP (`DALFormatError: ValueError: 1:0: syntax error`). The same thing happens with the code in the main branch, so I don't think it's a problem with this PR.
Update: `HEASARC_get_lightcurves` is working for me again. Seems to have been a transient issue on the archive side.