### PR TITLE
Bugfix ZTF import error

### DIFF
--- a/light_curves/code_src/ztf_functions.py
+++ b/light_curves/code_src/ztf_functions.py
@@ -8,7 +8,6 @@ import s3fs
 import tqdm
 
 from data_structures import MultiIndexDFObject
-from sample_selection import make_coordsTable
 
 # the catalog is stored in an AWS S3 bucket
 DATARELEASE = "dr18"


### PR DESCRIPTION
Fixes a bug that causes the `ZTF_get_lightcurve` import to fail.

This fix was originally in #176 but I'm pushing it through separately since that PR includes quite a few other changes.