### PR TITLE
Bugfix dtypes

### DIFF
--- a/light_curves/code_src/WISE_functions.py
+++ b/light_curves/code_src/WISE_functions.py
@@ -76,8 +76,7 @@ def locate_objects(sample_table, radius):
 
     locations = locations_table.to_pandas()
     # locations contains one row per object, and the pixel column stores arrays of ints
-    # "explode" the dataframe into one row per object per pixel
-    # this may create multiple rows per object, the pixel column will now store single ints
+    # "explode" the dataframe into one row per object per pixel. may create multiple rows per object
     return locations.explode(["pixel"], ignore_index=True)
 
 

--- a/light_curves/code_src/ztf_functions.py
+++ b/light_curves/code_src/ztf_functions.py
@@ -301,8 +301,9 @@ def transform_lightcurves(ztf_df):
     # if your science depends on precise times, this will need to be corrected.
     ztf_df = ztf_df.rename(columns={"hmjd": "time"})
 
-    # "explode" the data structure into one row per light curve point
+    # "explode" the data structure into one row per light curve point and set the correct dtypes
     ztf_df = ztf_df.explode(["time", "mag", "magerr", "catflags"], ignore_index=True)
+    ztf_df = ztf_df.astype({"time": "float", "mag": "float", "magerr": "float", "catflags": "int"})
 
     # remove data flagged as bad
     ztf_df = ztf_df.loc[ztf_df["catflags"] < 32768, :]

--- a/light_curves/lc_classifier.md
+++ b/light_curves/lc_classifier.md
@@ -353,6 +353,7 @@ df_empty = pd.DataFrame(zerosingle_list)
 # df_empty has one row per dict. time,flux, and err columns store arrays.
 # "explode" the dataframe to get one row per light curve point. time, flux, and err columns will now store floats.
 df_empty = df_empty.explode(["time", "flux","err"], ignore_index=True)
+df_empty = df_empty.astype({col: "float" for col in ["time", "flux", "err"]})
 
 
 #now put the empty light curves back together with the main light curve dataframe
@@ -438,6 +439,7 @@ df_interpol = pd.DataFrame(lc_interpol)
 # df_lc_interpol has one row per dict in lc_interpol. time and flux columns store arrays.
 # "explode" the dataframe to get one row per light curve point. time and flux columns will now store floats.
 df_lc = df_interpol.explode(["time", "flux","err"], ignore_index=True)
+df_lc = df_lc.astype({col: "float" for col in ["time", "flux", "err"]})
 
 #somehow data types for some columns are coming in as 'object' which sktime doesn't like
 #instead make them numeric data types

--- a/light_curves/lc_classifier.md
+++ b/light_curves/lc_classifier.md
@@ -440,11 +440,6 @@ df_interpol = pd.DataFrame(lc_interpol)
 # "explode" the dataframe to get one row per light curve point. time and flux columns will now store floats.
 df_lc = df_interpol.explode(["time", "flux","err"], ignore_index=True)
 df_lc = df_lc.astype({col: "float" for col in ["time", "flux", "err"]})
-
-#somehow data types for some columns are coming in as 'object' which sktime doesn't like
-#instead make them numeric data types
-cols = ["time", "flux", "err"]
-df_lc[cols] = df_lc[cols].apply(pd.to_numeric, errors='coerce')
 ```
 
 ### 2.6  Restructure dataframe in format expected by sktime


### PR DESCRIPTION
I just noticed that the flux and error dtypes are "object" in the light curve dataframe. I'm not aware of any problems this currently causes, but it might in the future. These really should be floats. This is happening because the pandas `explode` method returns columns with "object" dtypes. So, this PR sets the correct dtypes right after every `explode`.