### PR TITLE
Bugfix Table to DataFrame conversion

### DIFF
--- a/light_curves/code_src/WISE_functions.py
+++ b/light_curves/code_src/WISE_functions.py
@@ -61,7 +61,7 @@ def locate_objects(sample_table, radius):
     Returns
     -------
     locations : pd.DataFrame
-        dataframe of location info including ["objectid", "coord", "label", "pixel"]
+        dataframe of location info including ["objectid", "coord.ra", "coord.dec", "label", "pixel"]
     """
     # loop over objects and determine which HEALPix pixels overlap with a circle of r=`radius` around it
     # this determines which catalog partitions contain each object
@@ -70,11 +70,9 @@ def locate_objects(sample_table, radius):
                                          nside=hpgeom.order_to_nside(K), nest=True, inclusive=True)
                      for row in sample_table]
 
-    # TODO: simplify, e.g. avoid switching between Table and DF
-    locations_table = sample_table.copy()
-    locations_table['pixel'] = healpix_pixel
+    locations = sample_table.to_pandas()
+    locations['pixel'] = healpix_pixel
 
-    locations = locations_table.to_pandas()
     # locations contains one row per object, and the pixel column stores arrays of ints
     # "explode" the dataframe into one row per object per pixel
     # this may create multiple rows per object, the pixel column will now store single ints


### PR DESCRIPTION
An error occurs in the WISE function under rare circumstances when the number HEALPix pixels to be searched is the same for all sample objects. In this case, Astropy attaches the pixel column as a fixed-length array rather than an "object" dtype, and a Table with this column type cannot be converted to a DataFrame. This PR switches the order of operations so the Table is first converted to a DataFrame and then the pixel column is attached.

 Steps to reproduce the error:

```
import astropy.units as u
# assuming you're in the directory light_curves/code_src
from sample_selection import clean_sample, get_yang_sample
from WISE_functions import WISE_get_lightcurves

coords =[]
labels = []
get_yang_sample(coords, labels)   #2018ApJ...862..109Y
sample_table = clean_sample(coords, labels)

bandlist = ['W1', 'W2']
WISE_radius = 1.0 * u.arcsec

# send only the first 2 sample objects. on the main branch, this fails with a ValueError.
WISE_get_lightcurves(sample_table[:2], WISE_radius, bandlist)
```