### PR TITLE
CI: adding publishing GHA

### DIFF
--- a/.github/workflows/ci_publish.yml
+++ b/.github/workflows/ci_publish.yml
@@ -1,0 +1,43 @@
+name: Publish HTML
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '0 5 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  publish:
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    name: Publish HTML
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: python -m pip install --upgrade tox
+
+      - name: Execute notebooks as testing
+        run: tox -e py311-buildhtml
+
+      - name: Publish
+        uses: peaceiris/actions-gh-pages@v3.6.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_build/html/
+          commit_message: ${{ github.event.head_commit.message }}

--- a/site-requirements.txt
+++ b/site-requirements.txt
@@ -1,0 +1,4 @@
+sphinx
+myst-nb
+sphinx-book-theme
+sphinx-copybutton

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,24 @@
+[tox]
+envlist =
+    py{311}-buildhtml
+requires =
+    pip >= 19.3.1
+
+[testenv]
+
+description = run tests and build html
+
+deps =
+    # We use these files to specify all the dependencies, and below we override
+    # versions for specific testing scenarios
+    buildhtml: -rsite-requirements.txt
+
+
+allowlist_externals = bash
+
+commands =
+    pip freeze
+
+    buildhtml: sphinx-build -b html . _build/html -D nb_execution_mode=off -nWT --keep-going
+
+skip_install = true


### PR DESCRIPTION
This still works with the empty notebooks, I'm still not sure what the best place would be for the set of executed ones that we could tag with versions, etc.


Anyway, I'm going ahead and merge this as we see whether this resolves the permission issues around the `_static` directory or not. 

(also, note: the newer version of the theme looks different than the one I had locally, most of it is an improvement, but e.g. now we lack the title from below the logo, and that has to be fixed)