### PR TITLE
Clean up warnings

### DIFF
--- a/light_curves/code_src/HCV_functions.py
+++ b/light_curves/code_src/HCV_functions.py
@@ -245,38 +245,36 @@ def HCV_get_lightcurves(sample_table, radius):
         #look in the summary table for anything within a radius of our targets
         tab = hcvcone(ra,dec,radius,table="hcvsummary")
         if tab == '':
-            print (objectid, 'no matches')
-        else:
-            #print(ccount, 'got a live one')
-        
-            tab = ascii.read(tab)
-                
-            matchid = tab['MatchID'][0]  #take the first one, assuming it is the nearest match
-        
-            #just pulling one filter for an example (more filters are available)
-            try:
-                src_814 = ascii.read(hcvsearch(table='hcv',MatchID=matchid,Filter='ACS_F814W'))
-            except FileNotFoundError:
-                #that filter doesn't exist for this target
-                print("no F814W filter info for this target")
-            else:        
-                time_814 = src_814['MJD']
-                mag_814 = src_814['CorrMag']  #need to convert this to flux
-                magerr_814 = src_814['MagErr']
-
-                filterstring = 'F814W'
-
-                #uggg, ACS has time dependent flux zero points.....
-                #going to cheat for now and only use one time, but could imagine this as a loop
-                #https://www.stsci.edu/hst/instrumentation/acs/data-analysis/zeropoints
-                flux, fluxerr = convertACSmagtoflux(time_814[0], filterstring, mag_814, magerr_814)
-                flux = flux *1E3 #convert to mJy
-                fluxerr = fluxerr*1E3 #convert to mJy
+            continue
+    
+        tab = ascii.read(tab)
             
-                #put this single object light curves into a pandas multiindex dataframe
-                dfsingle_814 = pd.DataFrame(dict(flux=flux, err=fluxerr, time=time_814, objectid=objectid, band='F814W',label=lab)).set_index(["objectid", "label", "band", "time"])
+        matchid = tab['MatchID'][0]  #take the first one, assuming it is the nearest match
+    
+        #just pulling one filter for an example (more filters are available)
+        try:
+            src_814 = ascii.read(hcvsearch(table='hcv',MatchID=matchid,Filter='ACS_F814W'))
+        except FileNotFoundError:
+            #that filter doesn't exist for this target
+            continue
 
-                #then concatenate each individual df together
-                df_lc.append(dfsingle_814)
+        time_814 = src_814['MJD']
+        mag_814 = src_814['CorrMag']  #need to convert this to flux
+        magerr_814 = src_814['MagErr']
+
+        filterstring = 'F814W'
+
+        #uggg, ACS has time dependent flux zero points.....
+        #going to cheat for now and only use one time, but could imagine this as a loop
+        #https://www.stsci.edu/hst/instrumentation/acs/data-analysis/zeropoints
+        flux, fluxerr = convertACSmagtoflux(time_814[0], filterstring, mag_814, magerr_814)
+        flux = flux *1E3 #convert to mJy
+        fluxerr = fluxerr*1E3 #convert to mJy
+    
+        #put this single object light curves into a pandas multiindex dataframe
+        dfsingle_814 = pd.DataFrame(dict(flux=flux, err=fluxerr, time=time_814, objectid=objectid, band='F814W',label=lab)).set_index(["objectid", "label", "band", "time"])
+
+        #then concatenate each individual df together
+        df_lc.append(dfsingle_814)
             
     return(df_lc)

--- a/light_curves/code_src/plot_functions.py
+++ b/light_curves/code_src/plot_functions.py
@@ -213,7 +213,6 @@ def create_figures(sample_table , df_lc, show_nbr_figures, save_output):
         axes["B"].tick_params(axis="both", which="minor",direction='in', length=3, width=1)
 
         plt.legend(handles=leg_handles_A , bbox_to_anchor=(1.2,3.5), title=f"objectid: {objectid}")
-        plt.tight_layout()
 
         if save_output:
             savename = os.path.join("output" , "lightcurve_{}.pdf".format(objectid) ) 

--- a/light_curves/light_curve_generator.md
+++ b/light_curves/light_curve_generator.md
@@ -409,6 +409,9 @@ with mp.Pool(processes=n_workers) as pool:
     pool.join()  # wait for all jobs to complete, including the callback
 
 parallel_endtime = time.time()
+
+# LightKurve will return an "Error" when it doesn't find a match for a target
+# These are not real errors and can be safely ignored.
 ```
 
 ```{code-cell} ipython3

--- a/light_curves/light_curve_generator.md
+++ b/light_curves/light_curve_generator.md
@@ -73,13 +73,10 @@ MAST, HEASARC, & IRSA Fornax teams
 import multiprocessing as mp
 import sys
 import time
-import warnings
 
 import astropy.units as u
 import pandas as pd
 from astropy.table import Table
-
-warnings.filterwarnings('ignore')
 
 # local code imports
 sys.path.append('code_src/')


### PR DESCRIPTION
Closes #174 

- Remove warnings filter from main notebook.
- Remove `plt.tight_layout` from plotting function. It is throwing a warning, and the figures look good to me without it.
- Add comment that it's ok to ignore the lightkurve "error".
- Remove print statements from `HCV_get_lightcurves`.