### PR TITLE
Clean up plot_functions.py

### DIFF
--- a/light_curves/code_src/plot_functions.py
+++ b/light_curves/code_src/plot_functions.py
@@ -7,32 +7,6 @@ from astropy.table import Table
 from scipy import stats
 
 
-def setup_text_plots():
-    """
-    This function adjusts matplotlib settings so that all figures have a uniform format and look.
-    """
-    mpl.rcParams['font.size'] = 14
-    mpl.rcParams['axes.labelpad'] = 7
-    mpl.rcParams['xtick.major.pad'] = 7
-    mpl.rcParams['ytick.major.pad'] = 7
-    mpl.rcParams['xtick.minor.visible'] = True
-    mpl.rcParams['ytick.minor.visible'] = True
-    mpl.rcParams['xtick.minor.top'] = True
-    mpl.rcParams['xtick.minor.bottom'] = True
-    mpl.rcParams['ytick.minor.left'] = True
-    mpl.rcParams['ytick.minor.right'] = True
-    mpl.rcParams['xtick.major.size'] = 5
-    mpl.rcParams['ytick.major.size'] = 5
-    mpl.rcParams['xtick.minor.size'] = 3
-    mpl.rcParams['ytick.minor.size'] = 3
-    mpl.rcParams['xtick.direction'] = 'in'
-    mpl.rcParams['ytick.direction'] = 'in'
-    #mpl.rc('text', usetex=True)
-    mpl.rc('font', family='serif')
-    mpl.rcParams['xtick.top'] = True
-    mpl.rcParams['ytick.right'] = True
-    mpl.rcParams['hatch.linewidth'] = 1
-
 def create_figures(df_lc, show_nbr_figures, save_output):
     '''
     Creates figures of the lightcurves for each object in df_lc.

--- a/light_curves/code_src/plot_functions.py
+++ b/light_curves/code_src/plot_functions.py
@@ -114,6 +114,9 @@ def _clean_lightcurves(singleobj_df):
     # Switch the index to columns (reset) so they can be plotted.
     singleobj = singleobj_df.sort_index().reset_index()
 
+    # Remove rows containing NaN in time, flux, or err
+    singleobj = singleobj.dropna(subset=["time", "flux", "err"])
+
     # Do sigma-clipping per band.
     band_groups = singleobj.groupby("band").flux
     zscore = band_groups.transform(lambda fluxes: np.abs(stats.zscore(fluxes)))

--- a/light_curves/light_curve_generator.md
+++ b/light_curves/light_curve_generator.md
@@ -440,8 +440,7 @@ These plots are modelled after [van Velzen et al., 2021](https://arxiv.org/pdf/2
 __Note__ that in the following, we can either plot the results from `df_lc` (from the serial call) or `parallel_df_lc` (from the parallel call). By default (see next cell) the output of the parallel call is used.
 
 ```{code-cell} ipython3
-_ = create_figures(sample_table ,
-                   df_lc = parallel_df_lc, # either df_lc (serial call) or parallel_df_lc (parallel call)
+_ = create_figures(df_lc = parallel_df_lc, # either df_lc (serial call) or parallel_df_lc (parallel call)
                    show_nbr_figures = 5,  # how many plots do you actually want to see?
                    save_output = True ,  # should the resulting plots be saved?
                   )


### PR DESCRIPTION
Closes #199 
(This should be merged *after* #198)

## Changes
- separate `create_figures` into smaller functions
- remove `sample_table` arg and `cc` manual counter
- remove unused function `setup_text_plots`

## Of Note

Bands with fluxes in electrons/sec ('Kepler', 'K2', 'TESS') are now scaled based on all bands with fluxes in mJy. Previously they were being scaled based only on the bands that had actually been plotted before the electrons/sec bands; and if no bands had already been plotted, the electrons/sec band was omitted. I can provide figures for comparison if anyone wants to see them.

I have removed the line that dropped data points with "time" > 65000 MJD (= 2036-11-03). I checked the Yang sample and the first 100 objects in the SDSS sample and did not find any such data points. If there was a specific need for that line, please let me know. It seems to me that, if there are any such data points, they should be dropped from the dataframe altogether, not just for plotting.