### PR TITLE
Avoid leaked semaphores

### DIFF
--- a/light_curves/light_curve_generator.md
+++ b/light_curves/light_curve_generator.md
@@ -52,7 +52,6 @@ By the end of this tutorial, you will be able to:
  &bull; `pyarrow` to work with Parquet files for WISE and ZTF  
  &bull; `pyvo` for acessing Virtual Observatory(VO) standard data  
  &bull; `requests` to get information from URLs  
- &bull; `s3fs` to connect to AWS S3 buckets  
  &bull; `scipy` to do statistics  
  &bull; `tqdm` to track progress on long running jobs  
  &bull; `urllib` to handle archive searches with website interface

--- a/light_curves/light_curve_generator.md
+++ b/light_curves/light_curve_generator.md
@@ -352,11 +352,6 @@ hcv_radius = 1.0 / 3600.0  # radius = 1 arcsec
 # number of workers to use in the parallel processing pool
 # this should equal the total number of archives called
 n_workers = 8
-
-# "spawn" new processes because it uses less memory and is thread safe
-# in particular, this is required for pd.read_parquet (used by ZTF_get_lightcurve)
-# https://stackoverflow.com/questions/64095876/multiprocessing-fork-vs-spawn
-mp.set_start_method("spawn", force=True)
 ```
 
 ```{code-cell} ipython3

--- a/light_curves/requirements.txt
+++ b/light_curves/requirements.txt
@@ -14,7 +14,6 @@ pyarrow
 pyvo
 scikit-learn
 scipy
-s3fs>=23.10.0
 tqdm
 alerce
 umap-learn[plot]


### PR DESCRIPTION
## Background

We have been encountering "leaked semaphore" warnings occasionally. It's difficult to track down exactly where this is coming from, but I believe we are experiencing issue https://github.com/python/cpython/issues/90549 which reports a bug in python's `multiprocessing` stemming from the combined use of global resources and "spawning" new processes*. We have been using "spawn" (over the default "fork") because it is thread-safe, which is required for `pd.read_parquet`, which was being used by  `ZTF_get_lightcurve`. This PR replaces `pd.read_parquet` with a pyarrow method and switches multiprocessing to "fork".

*Note: A fix has been backported to python>=3.10. I'm still getting the warning using 3.10, but I can't tell if I'm using a version that includes the backport.

## Included Changes

- Remove calls to `mp.set_start_method("spawn")`.
- Replace `pd.read_parquet(..)` with `pyarrow.parquet.read_table(..).to_pandas()`.
- Replace filesystem handler `s3fs` with `pyarrow.fs`. This is not strictly necessary, but it's convenient to just use pyarrow for everything. Since no other modules depend on `s3fs`, I have also removed it from the explicit requirements for light curves. Please let me know if you would prefer to keep it (maybe @bsipocz).