### PR TITLE
Enhance sample_selection.py

### DIFF
--- a/light_curves/code_src/sample_selection.py
+++ b/light_curves/code_src/sample_selection.py
@@ -1,6 +1,7 @@
 from requests.exceptions import ConnectionError
 
 import astropy.units as u
+from alerce.core import Alerce
 from astropy.coordinates import SkyCoord
 from astropy.table import Table, join, join_skycoord, unique
 from astroquery.ipac.ned import Ned
@@ -315,6 +316,30 @@ def get_graham_sample(coords, labels, *, verbose=1):
         labels.append('Graham 19')
     if verbose:
         print('Changing Look AGN- Graham et al: ',len(CSQ))
+
+
+def get_ztf_objectid_sample(coords, labels, *, objectids=["ZTF18aabtxvd", "ZTF18aahqkbt"], verbose=1):
+    """ To find and append coordinates of objects with only ZTF obj name
+
+    Parameters
+    ----------
+    coords : list of astropy skycoords
+        the coordinates of the targets for which a user wants light curves
+    labels: list of strings
+        journal articles associated with the target coordinates
+    objectids: list of strings
+        List of ZTF objectid. eg., [ "ZTF18accqogs", "ZTF19aakyhxi", "ZTF19abyylzv", "ZTF19acyfpno"]
+    verbose: int
+        print out debugging info (1) or not(0)
+    """
+    alerce = Alerce()
+    objects = alerce.query_objects(oid=objectids, format="pandas")
+    tde_coords = [SkyCoord(ra, dec, frame='icrs', unit='deg') for ra, dec in zip(objects['meanra'], objects['meandec'])]
+    tde_labels = ['ZTF-Objname' for _ in objects['meanra']]
+    coords.extend(tde_coords)
+    labels.extend(tde_labels)
+    if verbose:
+        print('number of ztf coords added by Objectname:', len(objects['meanra']))
 
 
 #SDSS QSO sample of any desired number

--- a/light_curves/code_src/sample_selection.py
+++ b/light_curves/code_src/sample_selection.py
@@ -1,3 +1,5 @@
+from requests.exceptions import ConnectionError
+
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.table import Table, join, join_skycoord, unique
@@ -372,7 +374,11 @@ def get_paper_sample(coords, labels, *, paper_link="2019A&A...627A..33D", label=
     verbose : int, optional
         Print out the length of the sample derived from this literature source
     """
-    paper = Ned.query_refcode(paper_link)
+    try:
+        paper = Ned.query_refcode(paper_link)
+    except ConnectionError:
+        print(f"WARNING: encountered a ConnectionError error for paper {paper_link}. skipping.")
+        return
 
     paper_coords = [SkyCoord(ra, dec, frame='icrs', unit='deg') for ra, dec in zip(paper['RA'], paper['DEC'])]
     paper_labels = [label for ra in paper['RA']]

--- a/light_curves/code_src/sample_selection.py
+++ b/light_curves/code_src/sample_selection.py
@@ -430,6 +430,32 @@ def get_papers_list_sample(coords, labels, *, paper_kwargs=[dict(),]):
         get_paper_sample(coords, labels, **kwargs)
 
 
+def get_csv_sample(coords, labels, *, csv_path, label, ra_colname="ra", dec_colname="dec", frame="icrs", unit="deg"):
+    """Loads coordinates from file at `csv_path` and adds them to `coords` and `lables`
+
+    Parameters
+    ----------
+    coords : list
+        list of Astropy SkyCoords derived from literature sources, shared amongst functions
+    lables : list
+        List of the first author name and publication year for tracking the sources, shared amongst functions
+    csv_path : str
+        Path to a csv file containing (at least) columns 
+    label : str
+        The label to apply to these coordinates.
+    ra_colname : str
+        Name of the column containing the RA coord.
+    dec_colname : str
+        Name of the column containing the Dec coord.
+    frame : str
+        Coordinate frame to pass to SkyCoord.
+    unit : str
+        Coordinate unit to pass to SkyCoord.
+    """
+    csv_sample = Table.read(csv_path)[ra_colname, dec_colname]
+    coords.extend([SkyCoord(ra, dec, frame=frame, unit=unit) for (ra, dec) in csv_sample.iterrows()])
+    labels.extend([label] * len(csv_sample))
+
 
 def clean_sample(coords_list, labels_list, *, consolidate_nearby_objects=True, verbose=1):
     """Create a Table with objectid, skycoords, and labels.

--- a/light_curves/code_src/sample_selection.py
+++ b/light_curves/code_src/sample_selection.py
@@ -413,6 +413,24 @@ def get_paper_sample(coords, labels, *, paper_link="2019A&A...627A..33D", label=
         print("number of sources added from "+str(label)+" :"+str(len(paper_coords)))
 
 
+def get_papers_list_sample(coords, labels, *, paper_kwargs=[dict(),]):
+    """Wrapper for get_paper_sample. Calls get_paper_sample for each item in paper_kwargs.
+
+    Parameters
+    ----------
+    coords : list
+        list of Astropy SkyCoords derived from literature sources, shared amongst functions
+    lables : list
+        List of the first author name and publication year for tracking the sources, shared amongst functions
+    paper_kwargs : list[dict]
+        List of dicts containing keyword arguments passed on to get_paper_sample.
+    """
+    # loop over the papers in paper_kwargs and call get_paper_sample for each
+    for kwargs in paper_kwargs:
+        get_paper_sample(coords, labels, **kwargs)
+
+
+
 def clean_sample(coords_list, labels_list, *, consolidate_nearby_objects=True, verbose=1):
     """Create a Table with objectid, skycoords, and labels.
 


### PR DESCRIPTION
Merge _after_ #230.

Changes to sample_selection.py:

- Add ~~`get_tde_sample`~~`get_ztf_objectid_sample` - Load sample by ZTF objectid.
- Add `get_csv_sample` - Load sample from CSV file containing (at least) RA and Dec.
- Add `get_papers_list_sample` - Wrapper for `get_paper_sample` to fetch multiple papers with one call (helpful for #215).
- Replace `nonunique_sample` with a kwarg in `clean_sample` called `consolidate_nearby_objects`.