### PR TITLE
Reorganize notebook sections

### DIFF
--- a/light_curves/light_curve_generator.md
+++ b/light_curves/light_curve_generator.md
@@ -323,10 +323,8 @@ print('total time for serial archive calls is ', end_serial - start_serial, 's')
 ## Make plots of luminosity as a function of time
 These plots are modelled after [van Velzen et al., 2021](https://arxiv.org/pdf/2111.09391.pdf). We show flux in mJy as a function of time for all available bands for each object. `show_nbr_figures` controls how many plots are actually generated and returned to the screen.  If you choose to save the plots with `save_output`, they will be put in the output directory and labelled by sample number.
 
-__Note__ that in the following, we can either plot the results from `df_lc` (from the serial call) or `parallel_df_lc` (from the parallel call). By default (see next cell) the output of the parallel call is used.
-
 ```{code-cell} ipython3
-_ = create_figures(df_lc = parallel_df_lc, # either df_lc (serial call) or parallel_df_lc (parallel call)
+_ = create_figures(df_lc = df_lc,
                    show_nbr_figures = 5,  # how many plots do you actually want to see?
                    save_output = True ,  # should the resulting plots be saved?
                   )

--- a/light_curves/light_curve_generator.md
+++ b/light_curves/light_curve_generator.md
@@ -294,7 +294,7 @@ df_lc.append(df_lc_gaia)
 print('gaia search took:', time.time() - gaiastarttime, 's')
 ```
 
-### 3.3 IceCube neutrinos
+#### 2.8 IceCube neutrinos
 
 There are several [catalogs](https://icecube.wisc.edu/data-releases/2021/01/all-sky-point-source-icecube-data-years-2008-2018) (basically one for each year of IceCube data from 2008 - 2018). The following code creates a large catalog by combining
 all the yearly catalogs.

--- a/light_curves/light_curve_generator.md
+++ b/light_curves/light_curve_generator.md
@@ -156,7 +156,7 @@ Do only this step from this section when you have a previously generated sample 
 sample_table = Table.read('data/input_sample.ecsv', format='ascii.ecsv')
 ```
 
-### 2. Call the archives
+### 2. Query the archives
 
 We search a curated list of time-domain catalogs from NASA and non-NASA astrophysics archives.  Because each archive is different, and in many cases each catalog is different, each function to access a catalog is necessarily specialized to the location and format of that particular catalog.
 
@@ -356,7 +356,7 @@ parallel_df_lc = MultiIndexDFObject()  # to collect the results
 callback = parallel_df_lc.append  # will be called once on the result returned by each archive
 with mp.Pool(processes=n_workers) as pool:
 
-    # start the processes that call the archives
+    # start the processes that query the archives
     pool.apply_async(gaia_get_lightcurves, args=(sample_table,), callback=callback)
     pool.apply_async(heasarc_get_lightcurves, args=(sample_table,), callback=callback)
     pool.apply_async(hcv_get_lightcurves, args=(sample_table,), callback=callback)


### PR DESCRIPTION
Merge _after_ #232 

In general, to me, the organizational structure of the light_curve_generator notebook feels hard to follow because of the section levels, names, and numbers. In particular, it would be easier to explain the new bulk-run script (#215) if the light-curve collection (serial) sections were grouped together and described as 2 main steps: define the sample, then call the archives. This PR suggests that we reorganize to the following new outline.

## New outline

- Make Multi-Wavelength Light Curves Using Archival Data
    - Learning Goals
    - Introduction
        - Input
        - Output
        - Imports
    - Collect Light Curves
        - \1. Define the sample  ("\\" is only here to prevent an auto-format to "a.")
            - 1.1 Build your own sample
            - 1.2 Write out your sample to disk
            - 1.3 Load the sample table from disk
        - \2. Query the archives
            - 2.1 NASA-HEASARC: FERMI & Beppo SAX
            - 2.2 IRSA: ZTF
            - 2.3 NASA-IRSA: WISE
            - 2.4 NASA-MAST: Pan-STARRS
            - 2.5 NASA-MAST: TESS, Kepler and K2
            - 2.6 NASA-MAST: Hubble Catalog of Variables (HCV)
            - 2.7 Gaia
            - 2.8 IceCube neutrinos
    - Make plots of luminosity as a function of time
    - Bulk Runs: Collect light curves using parallel processing
    - About This Notebook
        - Authors
        - Acknowledgements
        - References

## Current outline, for reference

- Make Multi-Wavelength Light Curves Using Archival Data
    - Learning Goals
    - Introduction:
    - Input:
    - Output:
    - Imports:
    - Authors:
    - Acknowledgements:
    - \1. Define the sample
    - \2. Find light curves for these targets in NASA catalogs
        - 2.1 HEASARC: FERMI & Beppo SAX
        - 2.2 IRSA: ZTF
        - 2.3 IRSA: WISE
        - 2.4 MAST: Pan-STARRS
        - 2.5 MAST: TESS, Kepler and K2
        - 2.6 MAST: Hubble Catalog of Variables ([HCV](https://archive.stsci.edu/hlsp/hcv))
    - \3. Find light curves for these targets in relevant, non-NASA catalogs
        - 3.1 Gaia
        - 3.3 IceCube neutrinos
    - \4. Parallel processing the archive calls
    - \5. Make plots of luminosity as a function of time
    - References