### PR TITLE
Add s3fs to requirements.txt

### DIFF
--- a/light_curves/requirements.txt
+++ b/light_curves/requirements.txt
@@ -12,6 +12,7 @@ numpy
 pandas
 pyarrow
 pyvo
+s3fs
 scikit-learn
 scikit-image
 scipy


### PR DESCRIPTION
`s3fs` was dropped as an explicit requirement in #214, but it is still an implicit requirement and does not get installed automatically. I keep having to install this manually on irsakusp, so we might as well add it back here.