### PR TITLE
ML classifier cleanup

### DIFF
--- a/light_curves/light_curve_classifier.md
+++ b/light_curves/light_curve_classifier.md
@@ -1030,21 +1030,21 @@ my_sample = my_sample[~my_sample["band"].isin(bands_to_drop)]
 my_sample.dropna(inplace = True, axis = 0)
 
 #remove outliers
-#make sure your sample has the same sigmaclip_value as were run to train the classifier
+#make sure your sample has the same sigmaclip_value as was run to train the classifier
 my_sample = sigmaclip_lightcurves(my_sample, sigmaclip_value, include_plot = False, verbose= False)
 
 #remove objects without W1 fluxes
 my_sample = remove_objects_without_band(my_sample, 'W1', verbose=False)
 
 #remove incomplete data
-#make sure your sample has the same threshole_too_few as were run to train the classifier
+#make sure your sample has the same threshold_too_few as were run to train the classifier
 my_sample = remove_incomplete_data(my_sample, threshold_too_few, verbose = False)
 
 #drop missing bands
 my_sample = missingdata_drop_bands(my_sample, bands_to_keep, verbose = False)
 
 #make arrays have uniform length and spacing
-final_freq_interpol = 60  #this is the timescale of interpolation in units of days
+#make sure your sample has the same final_feq_interpol as was run to train the classifier
 df_interpol = uniform_length_spacing(my_sample, final_freq_interpol, include_plot = False )
 my_sample = df_interpol.explode(["time", "flux","err"], ignore_index=True)
 my_sample = my_sample.astype({col: "float" for col in ["time", "flux", "err"]})
@@ -1061,12 +1061,9 @@ my_sample['datetime'] = mjd_to_datetime(my_sample)
 #set index expected by sktime
 my_sample = my_sample.set_index(["objectid", "label", "datetime"])
 
-#drop the uncertainty columns 
+#drop the uncertainty and time columns 
 my_sample.drop(columns = ['err_panstarrs_g',	'err_panstarrs_i',	'err_panstarrs_r',	'err_panstarrs_y',	
-                          'err_panstarrs_z',	'err_W1',	'err_W2',	'err_zg',	'err_zr'], inplace = True)
-
-#drop also the time column 
-my_sample.drop(columns = ['time'],inplace = True)
+                          'err_panstarrs_z',	'err_W1',	'err_W2',	'err_zg',	'err_zr','time'], inplace = True)
 
  #make X 
 X_mysample  = my_sample.droplevel('label')

--- a/light_curves/light_curve_classifier.md
+++ b/light_curves/light_curve_classifier.md
@@ -537,8 +537,8 @@ def missingdata_drop_bands(df_lc, bands_to_keep, verbose=False):
         
     """
     # drop all rows where 'band' is not in 'bands_to_keep'
-    bands_to_drop = set(df_lc.band.unique()) - set(bands_to_keep)
-    clean_df = df_lc.loc[~df_lc.band.isin(bands_to_drop)]
+    bands_to_remove = set(df_lc.band.unique()) - set(bands_to_keep)
+    clean_df = df_lc.loc[~df_lc.band.isin(bands_to_remove)]
 
     if verbose:
         #how many objects did we start with?
@@ -1001,21 +1001,21 @@ my_sample = my_sample.reset_index()
 
 # get rid of some of the bands that don't have enough data for all the sources
 #CLAGN are generall fainter targets, and therefore mostly not found in datasets like TESS & K2
-bands_to_drop = ["IceCube", "TESS", "FERMIGTRIG", "K2"]
+#make sure your sample has the same bands as were run to train the classifier
 my_sample = my_sample[~my_sample["band"].isin(bands_to_drop)]
 
 #drop rows which have Nans
 my_sample.dropna(inplace = True, axis = 0)
 
 #remove outliers
-sigmaclip_value = 10.0
+#make sure your sample has the same sigmaclip_value as were run to train the classifier
 my_sample = sigmaclip_lightcurves(my_sample, sigmaclip_value, include_plot = False, verbose= False)
 
 #remove objects without W1 fluxes
 my_sample = remove_objects_without_band(my_sample, 'W1', verbose=False)
 
 #remove incomplete data
-threshold_too_few = 3
+#make sure your sample has the same threshole_too_few as were run to train the classifier
 my_sample = remove_incomplete_data(my_sample, threshold_too_few, verbose = False)
 
 #drop missing bands

--- a/light_curves/light_curve_classifier.md
+++ b/light_curves/light_curve_classifier.md
@@ -842,11 +842,9 @@ check_is_mtype(X_train, mtype="pd-multiindex", scitype="Panel", return_metadata=
 
 ```{code-cell} ipython3
 %%time
-#lets check out a RandomIntervalClassifier 
-#at some point in developing this notebook it was performing the best for this classification task
 
 #setup the classifier
-clf = RandomIntervalClassifier(n_intervals = 20, n_jobs = -1, random_state = 43)
+clf = Arsenal(time_limit_in_minutes=1, n_jobs = -1)
 
 #fit the classifier on the training dataset
 clf.fit(X_train, y_train)
@@ -868,7 +866,7 @@ plt.show()
 
 Our method is to do a cursory check of a bunch of classifiers and then later drill down deeper on anything with good initial results.  We choose to run a loop over ~10 classifiers that seem promising and check the accuracy scores for each one.  Any classifier with a promising accuracy score could then be followed up with detailed hyperparameter tuning, or potentially with considering other classifiers in that same type.
 
-```{raw-cell}
+```{code-cell} ipython3
 %%time
 #This cell is currently not being run because it takes a while so is not good for testing/debugging
 
@@ -889,7 +887,7 @@ names = ["Arsenal",                     #kernel based
         "DummyClassifier"]             #Dummy - ignores input
 
 #for those with an impossible time limit, how long to let them run for before cutting off
-nmins = 10
+nmins = 3
 
 #these could certainly be more tailored
 classifier_call = [Arsenal(time_limit_in_minutes=nmins, n_jobs = -1), 
@@ -927,27 +925,34 @@ for name, clf in tqdm(zip(names, classifier_call)):
     disp.plot()
     plt.show()
 
-#just for keeping track, I also tried 
-#clf = SignatureClassifier(depth = 2, window_depth = 3, random_state = 43)
-#this fails to complete, and is a known limitation of this algorithm.  
 ```
 
-```{raw-cell}
+```{code-cell} ipython3
 #show the summary of the algorithms used and their accuracy score
 accscore_dict
 ```
 
-```{raw-cell}
+```{code-cell} ipython3
 #save statistics from these runs
 
 # Serialize data into file:
-json.dump( accscore_dict, open( "output/accscore.json", 'w' ) )
-json.dump( completeness_dict, open( "output/completeness.json", 'w' ) )
-json.dump( homogeneity_dict, open( "output/homogeneity.json", 'w' ) )
+#json.dump( accscore_dict, open( "output/accscore.json", 'w' ) )
+#json.dump( completeness_dict, open( "output/completeness.json", 'w' ) )
+#json.dump( homogeneity_dict, open( "output/homogeneity.json", 'w' ) )
 
 # Read data from file:
 #accscore_dict = json.load( open( "output/accscore.json") )
 ```
+
+## 5.0 Create a candidate list 
+Lets assume we now have a classifier which can accurately differentiate CLAGN from SDSS QSOs.  Now we would like to use that classifier on the full sample of ~500k SDSS QSOs to identify CLAGN candidates.  To do this, we need to:
+- read in the full dataframe of 500k SDSS light curves
+- get that dataset in the same format as what was fed into the classifiers
+- run clf.predict() on that re-formatted dataset
+- retrace those objectids to an ra & dec
+- write an observing proposal (ok, you have to do that one yourself)
+
++++
 
 ## References:
 Markus Löning, Anthony Bagnall, Sajaysurya Ganesh, Viktor Kazakov, Jason Lines, Franz Király (2019): “sktime: A Unified Interface for Machine Learning with Time Series”

--- a/light_curves/light_curve_classifier.md
+++ b/light_curves/light_curve_classifier.md
@@ -755,18 +755,36 @@ df_lc = local_normalization_max(df_lc, norm_column = "flux_W1")
       - SKtime wants multi-index
 
 ```{code-cell} ipython3
-#need to convert df_lc time into datetime
-mjd = df_lc.time
+def mjd_to_datetime(df_lc):
+    """
+    convert time column in dataframe into datetime
+       
+    Parameters
+    ----------
+    df_lc: Pandas dataframe with light curve info
 
-#convert to JD
-jd = mjd_to_jd(mjd)
+    Returns
+    --------
+    t.datetime: array of type datetime
+        
+    """
+    #need to convert df_lc time into datetime
+    mjd = df_lc.time
 
-#convert to individual components
-t = Time(jd, format = 'jd' )
+    #convert to JD
+    jd = mjd_to_jd(mjd)
 
-#t.datetime is now an array of type datetime
-#make it a column in the dataframe
-df_lc['datetime'] = t.datetime
+    #convert to individual components
+    t = Time(jd, format = 'jd' )
+
+    #t.datetime is now an array of type datetime
+    #make it a column in the dataframe
+    return t.datetime
+```
+
+```{code-cell} ipython3
+# need to make a datetime column
+df_lc['datetime'] = mjd_to_datetime(df_lc)
 ```
 
 ```{code-cell} ipython3
@@ -805,7 +823,6 @@ df_lc = df_lc.drop(columns=["label"]).set_index(["objectid", "datetime"])
 ```
 
 ```{code-cell} ipython3
-
 test_size = 0.25
 
 #want a stratified split based on label
@@ -1021,10 +1038,7 @@ my_sample = my_sample.reset_index()
 my_sample = local_normalization_max(my_sample, norm_column = "flux_W1")
 
 #make datetime column
-mjd = my_sample.time
-jd = mjd_to_jd(mjd)
-t = Time(jd, format = 'jd' )
-my_sample['datetime'] = t.datetime
+my_sample['datetime'] = mjd_to_datetime(my_sample)
 
 #set index expected by sktime
 my_sample = my_sample.set_index(["objectid", "label", "datetime"])
@@ -1038,7 +1052,6 @@ my_sample.drop(columns = ['time'],inplace = True)
 
  #make X 
 X_mysample  = my_sample.droplevel('label')
-
 ```
 
 ```{code-cell} ipython3

--- a/light_curves/light_curve_generator.md
+++ b/light_curves/light_curve_generator.md
@@ -4,11 +4,11 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.16.0
+    jupytext_version: 1.15.2
 kernelspec:
-  display_name: science_demo
+  display_name: Python 3 (ipykernel)
   language: python
-  name: conda-env-science_demo-py
+  name: python3
 ---
 
 # Make Multiwavelength Light Curves Using Archival Data

--- a/light_curves/light_curve_generator.md
+++ b/light_curves/light_curve_generator.md
@@ -4,11 +4,11 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.16.0
+    jupytext_version: 1.15.2
 kernelspec:
-  display_name: science_demo
+  display_name: Python 3 (ipykernel)
   language: python
-  name: conda-env-science_demo-py
+  name: python3
 ---
 
 # Make Multiwavelength Light Curves Using Archival Data
@@ -130,6 +130,9 @@ get_yang_sample(coords, labels)   #2018ApJ...862..109Y
 # Remove duplicates, attach an objectid to the coords,
 # convert to astropy table to keep all relevant info together
 sample_table = clean_sample(coords, labels)
+
+#give this sample a name for use in saving files
+sample_name = "yang_CLAGN"
 ```
 
 ### 1.1 Build your own sample
@@ -150,7 +153,8 @@ At this point you may wish to write out your sample to disk and reuse that in fu
 For the format of the save file, we would suggest to choose from various formats that fully support astropy objects(eg., SkyCoord).  One example that works is Enhanced Character-Separated Values or ['ecsv'](https://docs.astropy.org/en/stable/io/ascii/ecsv.html)
 
 ```{code-cell} ipython3
-sample_table.write('data/input_sample.ecsv', format='ascii.ecsv', overwrite = True)
+savename_sample = f"output/{sample_name}_sample.ecsv"
+sample_table.write(savename_sample, format='ascii.ecsv', overwrite = True)
 ```
 
 ### 1.3 Load the sample table from disk
@@ -158,7 +162,7 @@ sample_table.write('data/input_sample.ecsv', format='ascii.ecsv', overwrite = Tr
 Do only this step from this section when you have a previously generated sample table
 
 ```{code-cell} ipython3
-sample_table = Table.read('data/input_sample.ecsv', format='ascii.ecsv')
+sample_table = Table.read(savename_sample, format='ascii.ecsv')
 ```
 
 ### 1.4 Initialize data structure to hold the light curves
@@ -415,9 +419,9 @@ parallel_df_lc.data
 
 ```{code-cell} ipython3
 # Save the data for future use with ML notebook
-#parquet_savename = 'output/df_lc_090723_yang.parquet'
-#parallel_df_lc.data.to_parquet(parquet_savename)
-#print("file saved!")
+parquet_savename = f"output/{sample_name}_df_lc.parquet"
+parallel_df_lc.data.to_parquet(parquet_savename)
+print("file saved!")
 ```
 
 ```{code-cell} ipython3
@@ -448,7 +452,7 @@ This work made use of:
 &bull; Astropy; Astropy Collaboration 2022, Astropy Collaboration 2018, Astropy Collaboration 2013,    2022ApJ...935..167A, 2018AJ....156..123A, 2013A&A...558A..33A  
 &bull; Lightkurve; Lightkurve Collaboration 2018, 2018ascl.soft12013L  
 &bull; acstools; https://zenodo.org/record/7406933#.ZBH1HS-B0eY  
-&bull; unWISE light curves; Meisner et al., 2023, 2023AJ....165...36M  
+&bull; unWISE light curves; Meisner et al., 2023, 2023AJ....165...36M
 
 ```{code-cell} ipython3
 

--- a/light_curves/light_curve_generator.md
+++ b/light_curves/light_curve_generator.md
@@ -117,14 +117,14 @@ labels = []
 #get_lyu_sample(coords, labels)  #z32022ApJ...927..227L
 #get_lopeznavas_sample(coords, labels)  #2022MNRAS.513L..57L
 #get_hon_sample(coords, labels)  #2022MNRAS.511...54H
-#get_yang_sample(coords, labels)   #2018ApJ...862..109Y
+get_yang_sample(coords, labels)   #2018ApJ...862..109Y
 
 # Get some "normal" QSOs 
 # there are ~500K of these, so choose the number based on
 # a balance between speed of running the light curves and whatever 
 # the ML algorithms would like to have
 
-#num_normal_QSO = 300
+#num_normal_QSO = 5000
 #get_SDSS_sample(coords, labels, num_normal_QSO)
 
 # Remove duplicates, attach an objectid to the coords,

--- a/light_curves/light_curve_generator.md
+++ b/light_curves/light_curve_generator.md
@@ -4,11 +4,11 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.15.2
+    jupytext_version: 1.16.0
 kernelspec:
-  display_name: Python 3 (ipykernel)
+  display_name: science_demo
   language: python
-  name: python3
+  name: conda-env-science_demo-py
 ---
 
 # Make Multiwavelength Light Curves Using Archival Data
@@ -117,14 +117,14 @@ labels = []
 #get_lyu_sample(coords, labels)  #z32022ApJ...927..227L
 #get_lopeznavas_sample(coords, labels)  #2022MNRAS.513L..57L
 #get_hon_sample(coords, labels)  #2022MNRAS.511...54H
-get_yang_sample(coords, labels)   #2018ApJ...862..109Y
+#get_yang_sample(coords, labels)   #2018ApJ...862..109Y
 
 # Get some "normal" QSOs 
 # there are ~500K of these, so choose the number based on
 # a balance between speed of running the light curves and whatever 
 # the ML algorithms would like to have
 
-#num_normal_QSO = 5000
+#num_normal_QSO = 300
 #get_SDSS_sample(coords, labels, num_normal_QSO)
 
 # Remove duplicates, attach an objectid to the coords,
@@ -162,7 +162,7 @@ sample_table.write(savename_sample, format='ascii.ecsv', overwrite = True)
 Do only this step from this section when you have a previously generated sample table
 
 ```{code-cell} ipython3
-sample_table = Table.read(savename_sample, format='ascii.ecsv')
+#sample_table = Table.read(savename_sample, format='ascii.ecsv')
 ```
 
 ### 1.4 Initialize data structure to hold the light curves

--- a/light_curves/requirements-lc_classifier.txt
+++ b/light_curves/requirements-lc_classifier.txt
@@ -11,4 +11,3 @@ googledrivedownloader
 scikit-learn
 acstools
 requests
-pyts


### PR DESCRIPTION
Highlights of this PR include:
- light_curve_classifier: removes pyts. I realized that a demo notebook doens't need more than one set of ML algorithms and that can just be part of my research.
- light_curve_classifier: adds a section on predicting labels for a different sample once there is a trained classifier
- light_curve_classifier: edits a lot of text, checks function docstrings
- light_curve_classifier: adds a  section on data visualization to see what the light curves look like
- light_curve_generator: introduces a sample_name variable so that we can track the saved sample_table and df_lc that belong to the same sample.  Sorry this is probably causing a conflict with main.

I think the code now includes all the things I want it to include, and hopefully is in good shape for a code review.  I expect future PRs to just be updates and not massive changes.  The code does not take long to run at all and therefore does not need to be optimized for CPU/RAM in its current incarnation.  I have left all functions in the main notebook, but expect to move those out after review.