### PR TITLE
Spectroscopy Notebook Updates

### DIFF
--- a/spectroscopy/code_src/desi_functions.py
+++ b/spectroscopy/code_src/desi_functions.py
@@ -5,6 +5,7 @@ import numpy as np
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
+from astropy import nddata
 
 import pandas as pd
 
@@ -46,8 +47,8 @@ def DESIBOSS_get_spec(sample_table, search_radius_arcsec):
     for stab in sample_table:
     
         ## Search
-        data_releases = ['DESI-EDR','BOSS-DR16']
-        #data_releases = ['DESI-EDR','BOSS-DR16','SDSS-DR16']
+        #data_releases = ['DESI-EDR','BOSS-DR16']
+        data_releases = ['DESI-EDR','BOSS-DR16','SDSS-DR16']
         
         search_coords = stab["coord"]
         dra = (search_radius_arcsec*u.arcsec).to(u.degree)
@@ -60,7 +61,7 @@ def DESIBOSS_get_spec(sample_table, search_radius_arcsec):
                 'dec' : [search_coords.dec.deg-ddec.value  , search_coords.dec.deg+ddec.value ]
                }
         found_I = client.find(outfields=out, constraints=cons, limit=20) # search
-        #print(found_I)
+        print(found_I)
         
         ## Extract nice table and the spectra
         if len(found_I.records) > 0:

--- a/spectroscopy/code_src/desi_functions.py
+++ b/spectroscopy/code_src/desi_functions.py
@@ -61,7 +61,7 @@ def DESIBOSS_get_spec(sample_table, search_radius_arcsec):
                 'dec' : [search_coords.dec.deg-ddec.value  , search_coords.dec.deg+ddec.value ]
                }
         found_I = client.find(outfields=out, constraints=cons, limit=20) # search
-        print(found_I)
+        #print(found_I)
         
         ## Extract nice table and the spectra
         if len(found_I.records) > 0:

--- a/spectroscopy/code_src/desi_functions.py
+++ b/spectroscopy/code_src/desi_functions.py
@@ -47,8 +47,8 @@ def DESIBOSS_get_spec(sample_table, search_radius_arcsec):
     for stab in sample_table:
     
         ## Search
-        #data_releases = ['DESI-EDR','BOSS-DR16']
-        data_releases = ['DESI-EDR','BOSS-DR16','SDSS-DR16']
+        data_releases = ['DESI-EDR','BOSS-DR16']
+        #data_releases = ['DESI-EDR','BOSS-DR16','SDSS-DR16'] # we want to use DR17 directly using SDSS query
         
         search_coords = stab["coord"]
         dra = (search_radius_arcsec*u.arcsec).to(u.degree)

--- a/spectroscopy/code_src/mast_functions.py
+++ b/spectroscopy/code_src/mast_functions.py
@@ -151,11 +151,17 @@ def JWST_get_spec_helper(sample_table, search_radius_arcsec, datadir, verbose):
                     file_idx = np.where( [ tab["productFilename"][jj] in download_results["Local Path"][iii] for iii in range(len(download_results))] )[0]
                     
                     # open spectrum
+                    # Note that specutils returns the wrong units. Use Table.read() instead.
                     filepath = download_results["Local Path"][file_idx[0]]
-                    #print(filepath)
-                    spec1d = Spectrum1D.read(filepath)
+                    spec1d = Table.read(filepath , hdu=1)
                     
-                    dfsingle = pd.DataFrame(dict(wave=[spec1d.spectral_axis] , flux=[spec1d.flux], err=[np.repeat(0,len(spec1d.flux))],
+                    #print(filepath)
+                    #spec1d = Spectrum1D.read(filepath)
+                    
+                    dfsingle = pd.DataFrame(dict(#wave=[spec1d.spectral_axis] , flux=[spec1d.flux], err=[np.repeat(0,len(spec1d.flux))],,
+                                                 wave=[spec1d["WAVELENGTH"].data * spec1d["WAVELENGTH"].unit] ,
+                                                 flux=[spec1d["FLUX"].data * spec1d["FLUX"].unit],
+                                                 err=[spec1d["FLUX_ERROR"].data * spec1d["FLUX_ERROR"].unit],
                                                  label=[stab["label"]],
                                                  objectid=[stab["objectid"]],
                                                  #objID=[tab["objID"][jj]], # REMOVE
@@ -205,7 +211,7 @@ def JWST_group_spectra(df, verbose, quickplot):
     objects_unique = np.unique(tab["label"])
 
     for obj in objects_unique:
-        if verbose: print("++Processing Object {} ++".format(obj))
+        print("Grouping object {}".format(obj))
 
         ## Get filters
         filters_unique = np.unique(tab["filter"])
@@ -349,7 +355,8 @@ def HST_get_spec(sample_table, search_radius_arcsec, datadir, verbose):
                     spec1d = Spectrum1D.read(filepath)
 
                     # Note: this should be in erg/s/cm2/A and any wavelength unit.
-                    dfsingle = pd.DataFrame(dict(wave=[spec1d.spectral_axis] , flux=[spec1d.flux], err=[np.repeat(0,len(spec1d.flux))],
+                    dfsingle = pd.DataFrame(dict(#wave=[spec1d.spectral_axis] , flux=[spec1d.flux], err=[np.repeat(0,len(spec1d.flux))],
+                                                 wave=[spec1d.spectral_axis] , flux=[spec1d.flux], err=[spec1d.uncertainty.array * spec1d.uncertainty.unit],
                                                  label=[stab["label"]],
                                                  objectid=[stab["objectid"]],
                                                  #objID=[tab["objID"][jj]],

--- a/spectroscopy/code_src/mast_functions.py
+++ b/spectroscopy/code_src/mast_functions.py
@@ -14,6 +14,236 @@ from data_structures_spec import MultiIndexDFObject
 
 from specutils import Spectrum1D
 
+import matplotlib.pyplot as plt
+
+
+def JWST_get_spec(sample_table, search_radius_arcsec, datadir):
+    '''
+    Retrieves HST spectra for a list of sources and groups/stacks them.
+    This main function runs two sub-functions:
+    - JWST_get_spec_helper() which searches, downloads, retrieves the spectra
+    - JWST_group_spectra() which groups and stacks the spectra
+
+    Parameters
+    ----------
+    sample_table : `~astropy.table.Table`
+        Table with the coordinates and journal reference labels of the sources
+    search_radius_arcsec : `float`
+        Search radius in arcseconds.
+    datadir : `str`
+        Data directory where to store the data. Each function will create a
+        separate data directory (for example "[datadir]/HST/" for HST data).
+
+    Returns
+    -------
+    df_spec : MultiIndexDFObject
+        The main data structure to store all spectra
+        
+    '''
+
+    ## Get the spectra
+    print("Searching and Downloading Spectra... ")
+    df_jwst_all = JWST_get_spec_helper(sample_table, search_radius_arcsec, datadir)
+
+    ## Group
+    print("Grouping Spectra... ")
+    df_jwst_group = JWST_group_spectra(df_jwst_all, verbose=True, quickplot=True)
+
+
+    return(df_jwst_group)
+
+
+def JWST_get_spec_helper(sample_table, search_radius_arcsec, datadir):
+    '''
+    Retrieves HST spectra for a list of sources.
+
+    Parameters
+    ----------
+    sample_table : `~astropy.table.Table`
+        Table with the coordinates and journal reference labels of the sources
+    search_radius_arcsec : `float`
+        Search radius in arcseconds.
+    datadir : `str`
+        Data directory where to store the data. Each function will create a
+        separate data directory (for example "[datadir]/HST/" for HST data).
+
+    Returns
+    -------
+    df_spec : MultiIndexDFObject
+        The main data structure to store all spectra
+        
+    '''
+
+    ## Create directory
+    this_data_dir = os.path.join(datadir , "JWST/")
+    
+    
+    ## Initialize multi-index object:
+    df_spec = MultiIndexDFObject()
+    
+    for stab in sample_table:
+
+        print("Processing source {}".format(stab["label"]))
+
+        ## Query results
+        search_coords = stab["coord"]
+        query_results = Observations.query_criteria(coordinates = search_coords, radius = search_radius_arcsec * u.arcsec,
+                                                dataproduct_type=["spectrum"], obs_collection=["JWST"], intentType="science", calib_level=[3,4],
+                                                #instrument_name=['NIRSPEC/MSA', 'NIRSPEC/SLIT', 'NIRCAM/GRISM', 'NIRISS/WFSS'],
+                                                instrument_name=['NIRSPEC/MSA', 'NIRSPEC/SLIT'],
+                                                #filters=['CLEAR;PRISM','F070LP;G140M'],
+                                                dataRights=['PUBLIC']
+                                               )
+        print("Number of search results: {}".format(len(query_results)))
+
+        if len(query_results) > 0: # found some spectra
+            
+            
+            ## Retrieve spectra
+            data_products_list = Observations.get_product_list(query_results)
+            
+            ## Filter
+            data_products_list_filter = Observations.filter_products(data_products_list,
+                                                    productType=["SCIENCE"],
+                                                    #filters=['CLEAR;PRISM','F070LP;G140M'],
+                                                    #filters=['CLEAR;PRISM'],
+                                                    extension="fits",
+                                                    calib_level=[3,4], # only fully reduced or contributed
+                                                    productSubGroupDescription=["X1D"], # only 1D spectra
+                                                    dataRights=['PUBLIC'] # only public data
+                                                                    )
+            print("Number of files to download: {}".format(len(data_products_list_filter)))
+
+            if len(data_products_list_filter) > 0:
+                
+                ## Download
+                download_results = Observations.download_products(data_products_list_filter, download_dir=this_data_dir)
+            
+                
+                ## Create table
+                # NOTE: `download_results` has NOT the same order as `data_products_list_filter`. We therefore
+                # have to "manually" get the product file names here and then use those to open the files.
+                keys = ["filters","obs_collection","instrument_name","calib_level","t_obs_release","proposal_id","obsid","objID","distance"]
+                tab = Table(names=keys + ["productFilename"] , dtype=[str,str,str,int,float,int,int,int,float]+[str])
+                for jj in range(len(data_products_list_filter)):
+                    idx_cross = np.where(query_results["obsid"] == data_products_list_filter["obsID"][jj] )[0]
+                    tmp = query_results[idx_cross][keys]
+                    tab.add_row( list(tmp[0]) + [data_products_list_filter["productFilename"][jj]] )
+                print("number in table {}".format(len(tab)))
+                
+                ## Create multi-index object
+                for jj in range(len(tab)):
+
+                    # find correct path name:
+                    # Note that `download_results` does NOT have same order as `tab`!!
+                    file_idx = np.where( [ tab["productFilename"][jj] in download_results["Local Path"][iii] for iii in range(len(download_results))] )[0]
+                    
+                    # open spectrum
+                    filepath = download_results["Local Path"][file_idx[0]]
+                    print(filepath)
+                    spec1d = Spectrum1D.read(filepath)
+                    
+                    dfsingle = pd.DataFrame(dict(wave=[spec1d.spectral_axis] , flux=[spec1d.flux], err=[np.repeat(0,len(spec1d.flux))],
+                                                 label=[stab["label"]],
+                                                 objectid=[stab["objectid"]],
+                                                 #objID=[tab["objID"][jj]], # REMOVE
+                                                 #obsid=[tab["obsid"][jj]],
+                                                 mission=[tab["obs_collection"][jj]],
+                                                 instrument=[tab["instrument_name"][jj]],
+                                                 filter=[tab["filters"][jj]],
+                                                )).set_index(["objectid", "label", "filter", "mission"])
+                    df_spec.append(dfsingle)
+            
+            else:
+                print("Nothing to download for source {}.".format(stab["label"]))
+        else:
+            print("Source {} could not be found".format(stab["label"]))
+        
+
+    return(df_spec)
+
+def JWST_group_spectra(df, verbose, quickplot):
+    '''
+    Groups the JWST spectra and removes entries that have no spectra. Stacks
+    spectra that are similar and creates new DF.
+
+    Parameters
+    ----------
+    df : MultiIndexDFObject
+        Raw JWST multi-index object (output from `JWST_get_spec()`).
+    verbose : bool
+        Flag for verbosity: `True` or `False`
+    quickplot : bool
+        If `True`, quick plots are made for each spectral group.
+
+    Returns
+    -------
+    df_cons : MultiIndexDFObject
+        Consolidated and grouped data structure storing the spectra.
+        
+    '''
+
+    ## Initialize multi-index object:
+    df_spec = MultiIndexDFObject()
+    
+    ## Create data table from DF.
+    tab = df.data.reset_index()
+
+    ## Get objects
+    objects_unique = np.unique(tab["label"])
+
+    for obj in objects_unique:
+        if verbose: print("++Processing Object {} ++".format(obj))
+
+        ## Get filters
+        filters_unique = np.unique(tab["filter"])
+        if verbose: print("List of filters in data frame: {}".format( " | ".join(filters_unique)) )
+        
+        for filt in filters_unique:
+            if verbose: print("Processing {}: ".format(filt), end=" ")
+        
+            sel = np.where( (tab["filter"] == filt) & (tab["label"] == obj) )[0]
+            #tab_sel = tab.copy()[sel]
+            tab_sel = tab.iloc[sel]
+            if verbose: print("Number of items: {}".format( len(sel)), end=" | ")
+            
+            ## get good ones
+            sum_flux = np.asarray([np.nansum(tab_sel.iloc[iii]["flux"]).value for iii in range(len(tab_sel)) ])
+            idx_good = np.where(sum_flux > 0)[0]
+            if verbose: print("Number of good spectra: {}".format(len(idx_good)))
+        
+            if len(idx_good) > 0:
+                ## Create wavelength grid
+                wave_grid = tab_sel.iloc[idx_good[0]]["wave"] # NEED TO BE MADE BETTER LATER
+            
+                ## Interpolate fluxes
+                fluxes_int = np.asarray([ np.interp(wave_grid , tab_sel.iloc[idx]["wave"] , tab_sel.iloc[idx]["flux"]) for idx in idx_good ])
+                fluxes_units = [tab_sel.iloc[idx]["flux"].unit for idx in idx_good]
+                fluxes_stack = np.nanmedian(fluxes_int,axis=0)
+                if verbose: print("Units of fluxes for each spectrum: {}".format( ",".join([str(tt) for tt in fluxes_units]) ) )
+
+                ## Add to data frame
+                dfsingle = pd.DataFrame(dict(wave=[wave_grid * u.micrometer] , flux=[fluxes_stack * fluxes_units[0]], err=[np.repeat(0,len(fluxes_stack))],
+                                             label=[tab_sel["label"].iloc[0]],
+                                             objectid=[tab_sel["objectid"].iloc[0]],
+                                             mission=[tab_sel["mission"].iloc[0]],
+                                             instrument=[tab_sel["instrument"].iloc[0]],
+                                             filter=[tab_sel["filter"].iloc[0]],
+                                            )).set_index(["objectid", "label", "filter", "mission"])
+                df_spec.append(dfsingle)
+                
+                ## Quick plot
+                if quickplot:
+                    tmp = np.percentile(fluxes_stack, q=(1,50,99) )
+                    plt.plot(wave_grid , fluxes_stack)
+                    plt.ylim(tmp[0],tmp[2])
+                    plt.xlabel(r"Observed Wavelength [$\mu$m]")
+                    plt.ylabel(r"Flux [Jy]")
+                    plt.show()
+    
+    
+    return(df_spec)
+
 def HST_get_spec(sample_table, search_radius_arcsec, datadir):
     '''
     Retrieves HST spectra for a list of sources.

--- a/spectroscopy/code_src/sample_selection.py
+++ b/spectroscopy/code_src/sample_selection.py
@@ -8,7 +8,7 @@ from astropy.table import Table, join, join_skycoord, unique
 #from astroquery.vizier import Vizier
 
 
-def clean_sample(coords_list, labels_list, verbose=1):
+def clean_sample(coords_list, labels_list, precision, verbose=1):
     """Makes a unique sample of skycoords and labels with no repeats. Attaches an object ID to the coords.
 
     Parameters
@@ -17,6 +17,8 @@ def clean_sample(coords_list, labels_list, verbose=1):
         list of Astropy SkyCoords derived from literature sources
     labels_list : list
         List of the first author name and publication year for tracking the sources
+    precision : float (astropy units)
+        Precision of matching/removing doubles. For example 0.5*u.arcsecond.
     verbose : int, optional
         Print out the length of the sample after applying this function
 
@@ -31,7 +33,7 @@ def clean_sample(coords_list, labels_list, verbose=1):
     # now join the table with itself within a defined radius.
     # We keep one set of original column names to avoid later need for renaming
     tjoin = join(sample_table, sample_table, keys='coord',
-                 join_funcs={'coord': join_skycoord(0.005 * u.deg)},
+                 join_funcs={'coord': join_skycoord(precision)},
                  uniq_col_name='{col_name}{table_name}', table_names=['', '_2'])
 
     # this join will return 4 entries for each redundant coordinate:

--- a/spectroscopy/code_src/sdss_functions.py
+++ b/spectroscopy/code_src/sdss_functions.py
@@ -14,7 +14,7 @@ from data_structures_spec import MultiIndexDFObject
 
 from specutils import Spectrum1D
 
-def SDSS_get_spec(sample_table, search_radius_arcsec):
+def SDSS_get_spec(sample_table, search_radius_arcsec, data_release):
     '''
     Retrieves SDSS spectra for a list of sources. Note that no data will
     be directly downloaded. All will be saved in cache.
@@ -25,6 +25,8 @@ def SDSS_get_spec(sample_table, search_radius_arcsec):
         Table with the coordinates and journal reference labels of the sources
     search_radius_arcsec : `float`
         Search radius in arcseconds.
+    data_release : `int`
+        SDSS data release (e.g., 17 or 18)
 
     Returns
     -------
@@ -42,10 +44,10 @@ def SDSS_get_spec(sample_table, search_radius_arcsec):
         ## Get Spectra for SDSS
         search_coords = stab["coord"]
         
-        xid = SDSS.query_region(search_coords, radius=search_radius_arcsec * u.arcsec, spectro=True)
+        xid = SDSS.query_region(search_coords, radius=search_radius_arcsec * u.arcsec, spectro=True, data_release=data_release)
 
         if str(type(xid)) != "<class 'NoneType'>":
-            sp = SDSS.get_spectra(matches=xid, show_progress=True)
+            sp = SDSS.get_spectra(matches=xid, show_progress=True , data_release=data_release)
     
             ## Get data
             wave = 10**sp[0]["COADD"].data.loglam * u.angstrom # only one entry because we only search for one xid at a time. Could change that?

--- a/spectroscopy/spectra_generator.md
+++ b/spectroscopy/spectra_generator.md
@@ -134,14 +134,14 @@ labels = []
 coords.append(SkyCoord("{} {}".format("09 54 49.40" , "+09 16 15.9"), unit=(u.hourangle, u.deg) ))
 labels.append("NGC3049")
 
-#coords.append(SkyCoord("{} {}".format("12 45 17.44 " , "27 07 31.8"), unit=(u.hourangle, u.deg) ))
-#labels.append("NGC4670")
+coords.append(SkyCoord("{} {}".format("12 45 17.44 " , "27 07 31.8"), unit=(u.hourangle, u.deg) ))
+labels.append("NGC4670")
 
-#coords.append(SkyCoord("{} {}".format("14 01 19.92" , "−33 04 10.7"), unit=(u.hourangle, u.deg) ))
-#labels.append("Tol_89")
+coords.append(SkyCoord("{} {}".format("14 01 19.92" , "−33 04 10.7"), unit=(u.hourangle, u.deg) ))
+labels.append("Tol_89")
 
-#coords.append(SkyCoord(233.73856 , 23.50321, unit=u.deg ))
-#labels.append("Arp220")
+coords.append(SkyCoord(233.73856 , 23.50321, unit=u.deg ))
+labels.append("Arp220")
 
 coords.append(SkyCoord( 150.091 , 2.2745833, unit=u.deg ))
 labels.append("COSMOS1")
@@ -149,15 +149,14 @@ labels.append("COSMOS1")
 coords.append(SkyCoord( 150.1024475 , 2.2815559, unit=u.deg ))
 labels.append("COSMOS2")
 
-#coords.append(SkyCoord("{} {}".format("150.000" , "+2.00"), unit=(u.deg, u.deg) ))
-#labels.append("COSMOS3")
+coords.append(SkyCoord("{} {}".format("150.000" , "+2.00"), unit=(u.deg, u.deg) ))
+labels.append("COSMOS3")
 
 coords.append(SkyCoord("{} {}".format("+53.15508" , "-27.80178"), unit=(u.deg, u.deg) ))
 labels.append("JADESGS-z7-01-QU")
 
 coords.append(SkyCoord("{} {}".format("+53.15398", "-27.80095"), unit=(u.deg, u.deg) ))
 labels.append("TestJWST")
-
 
 sample_table = clean_sample(coords, labels, precision=2.0* u.arcsecond , verbose=1)
 

--- a/spectroscopy/spectra_generator.md
+++ b/spectroscopy/spectra_generator.md
@@ -131,7 +131,7 @@ Here we will define the sample of galaxies. For now, we just enter some "random"
 coords = []
 labels = []
 
-'''coords.append(SkyCoord("{} {}".format("09 54 49.40" , "+09 16 15.9"), unit=(u.hourangle, u.deg) ))
+coords.append(SkyCoord("{} {}".format("09 54 49.40" , "+09 16 15.9"), unit=(u.hourangle, u.deg) ))
 labels.append("NGC3049")
 
 coords.append(SkyCoord("{} {}".format("12 45 17.44 " , "27 07 31.8"), unit=(u.hourangle, u.deg) ))
@@ -150,19 +150,16 @@ coords.append(SkyCoord( 150.1024475 , 2.2815559, unit=u.deg ))
 labels.append("COSMOS2")
 
 coords.append(SkyCoord("{} {}".format("150.000" , "+2.00"), unit=(u.deg, u.deg) ))
-labels.append("None")'''
-
-#coords.append(SkyCoord("{} {}".format("09 54 49.40" , "+09 16 15.9"), unit=(u.hourangle, u.deg) ))
-#labels.append("NGC3049")
+labels.append("COSMOS3")
 
 coords.append(SkyCoord("{} {}".format("+53.15508" , "-27.80178"), unit=(u.deg, u.deg) ))
 labels.append("JADESGS-z7-01-QU")
 
 coords.append(SkyCoord("{} {}".format("+53.15398", "-27.80095"), unit=(u.deg, u.deg) ))
-labels.append("Test")
+labels.append("TestJWST")
 
 
-sample_table = clean_sample(coords, labels, precision=0.5 * u.arcsecond , verbose=1)
+sample_table = clean_sample(coords, labels, precision=2.0* u.arcsecond , verbose=1)
 
 print("Number of sources in sample table: {}".format(len(sample_table)))
 ```
@@ -225,9 +222,9 @@ df_spec.append(df_spec_IRS)
 
 This archive includes spectra taken by 
 
- &bull; HST
+ &bull; HST (including slit spectroscopy)
  
- &bull; JWST
+ &bull; JWST (including MSA and slit spectroscopy)
 
 
 ```python
@@ -237,50 +234,11 @@ df_spec_HST = HST_get_spec(sample_table , search_radius_arcsec = 0.5, datadir = 
 df_spec.append(df_spec_HST)
 ```
 
-```python jupyter={"source_hidden": true}
-## REPRODUCABLE EXAMPLE:
-'''
-## Query results
-search_coords = SkyCoord("{} {}".format("+53.15508" , "-27.80178"), unit=(u.deg, u.deg) )
-query_results = Observations.query_criteria(coordinates = search_coords, radius = 0.5 * u.arcsec,
-                                        dataproduct_type=["spectrum"], obs_collection=["JWST"], intentType="science", calib_level=[3,4],
-                                        instrument_name=['NIRSPEC/MSA', 'NIRSPEC/SLIT'],
-                                        filters=['CLEAR;PRISM'],
-                                        dataRights=['PUBLIC']
-                                       )
-print("Number of search results: {}".format(len(query_results)))
-
-## Retrieve spectra
-data_products_list = Observations.get_product_list(query_results)
-
-## Filter
-data_products_list_filter = Observations.filter_products(data_products_list,
-                                        productType=["SCIENCE"],
-                                        filters=['CLEAR;PRISM'],
-                                        extension="fits",
-                                        calib_level=[3,4], # only fully reduced or contributed
-                                        productSubGroupDescription=["X1D"], # only 1D spectra
-                                        dataRights=['PUBLIC'] # only public data
-                                                        )
-print("Number of files to download: {}".format(len(data_products_list_filter)))
-
-tmp = Table.read("./data/JWST/mastDownload/JWST/jw01180-o135_s00001_nirspec_clear-prism/jw01180-o135_s00001_nirspec_clear-prism_x1d.fits",hdu=1)
-plt.plot(tmp["WAVELENGTH"]/(1+7.3) , tmp["FLUX"])
-plt.xlim(0.1,0.5)
-#plt.yscale("log")
-#plt.ylim(1e-8,1e-7)
-plt.show()'''
-```
-
 ```python
 %%time
 ## Get Spectra for HST
 df_jwst = JWST_get_spec(sample_table , search_radius_arcsec = 0.5, datadir = "./data/")
 df_spec.append(df_jwst)
-```
-
-```python
-df_jwst.data
 ```
 
 ### 2.3 SDSS Archive
@@ -296,7 +254,8 @@ df_spec.append(df_spec_SDSS)
 
 ### 2.4 DESI Archive
 
-This includes DESI spectra. Here, we use the `SPARCL` query.
+This includes DESI spectra. Here, we use the `SPARCL` query. Note that this can also be used
+for SDSS searches, however, according to the SPARCL webpage, only up to DR16 is included.
 
 ```python
 %%time

--- a/spectroscopy/spectra_generator.md
+++ b/spectroscopy/spectra_generator.md
@@ -232,7 +232,7 @@ This archive includes spectra taken by
 ```python
 %%time
 ## Get Spectra for HST
-df_spec_HST = HST_get_spec(sample_table , search_radius_arcsec = 0.5, datadir = "./data/", verbose = True)
+df_spec_HST = HST_get_spec(sample_table , search_radius_arcsec = 0.5, datadir = "./data/", verbose = False)
 df_spec.append(df_spec_HST)
 ```
 
@@ -241,10 +241,6 @@ df_spec.append(df_spec_HST)
 ## Get Spectra for JWST
 df_jwst = JWST_get_spec(sample_table , search_radius_arcsec = 0.5, datadir = "./data/", verbose = False)
 df_spec.append(df_jwst)
-```
-
-```python
-df_spec.data
 ```
 
 ### 2.3 SDSS Archive

--- a/spectroscopy/spectra_generator.md
+++ b/spectroscopy/spectra_generator.md
@@ -134,14 +134,14 @@ labels = []
 coords.append(SkyCoord("{} {}".format("09 54 49.40" , "+09 16 15.9"), unit=(u.hourangle, u.deg) ))
 labels.append("NGC3049")
 
-coords.append(SkyCoord("{} {}".format("12 45 17.44 " , "27 07 31.8"), unit=(u.hourangle, u.deg) ))
-labels.append("NGC4670")
+#coords.append(SkyCoord("{} {}".format("12 45 17.44 " , "27 07 31.8"), unit=(u.hourangle, u.deg) ))
+#labels.append("NGC4670")
 
-coords.append(SkyCoord("{} {}".format("14 01 19.92" , "−33 04 10.7"), unit=(u.hourangle, u.deg) ))
-labels.append("Tol_89")
+#coords.append(SkyCoord("{} {}".format("14 01 19.92" , "−33 04 10.7"), unit=(u.hourangle, u.deg) ))
+#labels.append("Tol_89")
 
-coords.append(SkyCoord(233.73856 , 23.50321, unit=u.deg ))
-labels.append("Arp220")
+#coords.append(SkyCoord(233.73856 , 23.50321, unit=u.deg ))
+#labels.append("Arp220")
 
 coords.append(SkyCoord( 150.091 , 2.2745833, unit=u.deg ))
 labels.append("COSMOS1")
@@ -149,8 +149,8 @@ labels.append("COSMOS1")
 coords.append(SkyCoord( 150.1024475 , 2.2815559, unit=u.deg ))
 labels.append("COSMOS2")
 
-coords.append(SkyCoord("{} {}".format("150.000" , "+2.00"), unit=(u.deg, u.deg) ))
-labels.append("COSMOS3")
+#coords.append(SkyCoord("{} {}".format("150.000" , "+2.00"), unit=(u.deg, u.deg) ))
+#labels.append("COSMOS3")
 
 coords.append(SkyCoord("{} {}".format("+53.15508" , "-27.80178"), unit=(u.deg, u.deg) ))
 labels.append("JADESGS-z7-01-QU")
@@ -232,7 +232,7 @@ This archive includes spectra taken by
 ```python
 %%time
 ## Get Spectra for HST
-df_spec_HST = HST_get_spec(sample_table , search_radius_arcsec = 0.5, datadir = "./data/", verbose = False)
+df_spec_HST = HST_get_spec(sample_table , search_radius_arcsec = 0.5, datadir = "./data/", verbose = True)
 df_spec.append(df_spec_HST)
 ```
 
@@ -241,6 +241,10 @@ df_spec.append(df_spec_HST)
 ## Get Spectra for JWST
 df_jwst = JWST_get_spec(sample_table , search_radius_arcsec = 0.5, datadir = "./data/", verbose = False)
 df_spec.append(df_jwst)
+```
+
+```python
+df_spec.data
 ```
 
 ### 2.3 SDSS Archive

--- a/spectroscopy/spectra_generator.md
+++ b/spectroscopy/spectra_generator.md
@@ -101,7 +101,7 @@ Andreas Faisst, Jessica Krick, Shoubaneh Hemmati, Troy Raen, Brigitta Sipőcz, D
 
 ```python
 ## IMPORTS
-import sys
+import sys, os
 import numpy as np
 
 import matplotlib.pyplot as plt
@@ -161,16 +161,17 @@ labels.append("TestJWST")
 
 sample_table = clean_sample(coords, labels, precision=2.0* u.arcsecond , verbose=1)
 
-print("Number of sources in sample table: {}".format(len(sample_table)))
 ```
 
 ### 1.2 Write out your sample to disk
 
-At this point you may wish to write out your sample to disk and reuse that in future work sessions, instead of creating it from scratch again.
+At this point you may wish to write out your sample to disk and reuse that in future work sessions, instead of creating it from scratch again. Note that we first check if the `data` directory exists and if not, we will create one.
 
 For the format of the save file, we would suggest to choose from various formats that fully support astropy objects(eg., SkyCoord).  One example that works is Enhanced Character-Separated Values or ['ecsv'](https://docs.astropy.org/en/stable/io/ascii/ecsv.html)
 
 ```python
+if not os.path.exists("./data"):
+    os.mkdir("./data")
 sample_table.write('data/input_sample.ecsv', format='ascii.ecsv', overwrite = True)
 ```
 
@@ -207,15 +208,16 @@ This archive includes spectra taken by
 
 ```python
 %%time
-
 ## Get Keck Spectra (COSMOS only)
 df_spec_DEIMOS = KeckDEIMOS_get_spec(sample_table = sample_table, search_radius_arcsec=1)
 df_spec.append(df_spec_DEIMOS)
+```
 
+```python
+%%time
 ## Get Spitzer IRS Spectra
 df_spec_IRS = SpitzerIRS_get_spec(sample_table, search_radius_arcsec=1 , COMBINESPEC=False)
 df_spec.append(df_spec_IRS)
-
 ```
 
 ### 2.2 MAST Archive
@@ -230,14 +232,14 @@ This archive includes spectra taken by
 ```python
 %%time
 ## Get Spectra for HST
-df_spec_HST = HST_get_spec(sample_table , search_radius_arcsec = 0.5, datadir = "./data/")
+df_spec_HST = HST_get_spec(sample_table , search_radius_arcsec = 0.5, datadir = "./data/", verbose = False)
 df_spec.append(df_spec_HST)
 ```
 
 ```python
 %%time
-## Get Spectra for HST
-df_jwst = JWST_get_spec(sample_table , search_radius_arcsec = 0.5, datadir = "./data/")
+## Get Spectra for JWST
+df_jwst = JWST_get_spec(sample_table , search_radius_arcsec = 0.5, datadir = "./data/", verbose = False)
 df_spec.append(df_jwst)
 ```
 
@@ -255,11 +257,11 @@ df_spec.append(df_spec_SDSS)
 ### 2.4 DESI Archive
 
 This includes DESI spectra. Here, we use the `SPARCL` query. Note that this can also be used
-for SDSS searches, however, according to the SPARCL webpage, only up to DR16 is included.
+for SDSS searches, however, according to the SPARCL webpage, only up to DR16 is included. Therefore, we will not include SDSS DR16 here (this is treated in the SDSS search above).
 
 ```python
 %%time
-## Get DESI and BOSS and SDSS spectra with SPARCL
+## Get DESI and BOSS spectra with SPARCL
 df_spec_DESIBOSS = DESIBOSS_get_spec(sample_table, search_radius_arcsec=5)
 df_spec.append(df_spec_DESIBOSS)
 ```
@@ -277,3 +279,7 @@ create_figures(df_spec = df_spec,
              save_output = False,
              )
 ```
+
+<!-- #raw -->
+
+<!-- #endraw -->


### PR DESCRIPTION
The following changes were made:

- Include JWST MSA and Slit spectra (main update!)
- SPARCL query (DESI search) now includes SDSS-DR16 that can be used for comparison to DR17 search from SDSS archive. Note that according to the SPARCL webpage, DR17 is not yet included.
- Imported `nddata` package (astropy) in `desi_functions.py`. This was a bug.
- Bug fix in HST (and accordingly JWST) search functions: the order of file in the as output in the mast download function is not the same as the order of files in the product input list. This led to a mismatch if there are multiple spectra (especially the case for JWST). This has now been fixed.
- The `clean_sample()` function now has a `precision` argument where the user can set the precision (as astropy unit) at which coordinates are taken to be the same. This was implemented because the JWST MSA slits were too close together and in the current hard-coded threshold would be counted as overlapping.
- The `SDSS_get_spec()` function now has a `data_release` argument where the user can choose the SDSS data release. Currently, up to DR17 is supported. DR18 is not supported, yet, due to some inconsistencies on the `astroquery` backend (an [issue](https://github.com/astropy/astroquery/issues/3011) has been submitted, the likely culprit is a broken link to DR18).
- General updates in the documentation of `spectra_generator.md`.