### PR TITLE
Add herschel_get_spec functionality to spectroscopy notebook

### DIFF
--- a/spectroscopy/code_src/herschel_functions.py
+++ b/spectroscopy/code_src/herschel_functions.py
@@ -1,0 +1,152 @@
+## Herschel PACS & SPIRE (from ESA TAP)
+from astroquery.esa.hsa import HSA
+from astroquery.exceptions import LoginError
+from requests.exceptions import ChunkedEncodingError
+import tarfile 
+from astropy.io import fits
+import glob
+import pandas as pd
+import astropy.constants as const
+from astropy import units as u
+import os
+
+from data_structures_spec import MultiIndexDFObject
+
+def find_max_flux_column(df):
+  """
+  Analyzes a DataFrame with flux columns and returns the column with the largest sum.
+
+  Args:
+      df (pandas.DataFrame): The DataFrame containing columns with "flux" in the name.
+
+  Returns:
+      str: The name of the column with the largest sum of values containing "flux".
+  """
+
+  # Filter column names containing "flux"
+  flux_cols = [col for col in df.columns if "flux" in col.lower()]
+
+  # Check if any flux columns are found
+  if not flux_cols:
+    raise ValueError("No columns containing 'flux' found in the DataFrame")
+
+  # Calculate the sum of each flux column
+  flux_sums = {col: df[col].sum() for col in flux_cols}
+
+  # Find the column with the largest sum
+  max_flux_col = max(flux_sums, key=flux_sums.get)
+
+  return max_flux_col
+
+
+def Herschel_get_spec(sample_table, search_radius_arcsec, datadir, delete_tarfiles = False):
+    '''
+    Retrieves Herschel spectra from a subset of modes for a list of sources.
+
+    Parameters
+    ----------
+    sample_table : `~astropy.table.Table`
+        Table with the coordinates and journal reference labels of the sources
+    search_radius_arcsec : `float`
+        Search radius in arcseconds.
+    datadir : `str`
+        Data directory where to store the data. Each function will create a
+        separate data directory (for example "[datadir]/HST/" for HST data).
+    delete_tarfiles: True/False
+        Should the tarfiles be deteled after spectra are extracted?
+        
+    Returns
+    -------
+    df_spec : MultiIndexDFObject
+        The main data structure to store all spectra
+        
+    '''
+
+    ## Initialize multi-index object:
+    df_spec = MultiIndexDFObject()
+
+    for stab in sample_table:
+        search_coords = stab["coord"]
+        print("working on object", stab["label"])
+        
+        #first find the object ids from herschel then download the data for each observation id
+        #query_hsa_tap doesn't accept an upload_table, so do this so do this as a for loop over each instrument and object..
+ 
+        for instrument_name in ['PACS', 'SPIRE']:
+            querystring = "select top 10 observation_id from hsa.v_active_observation join hsa.instrument using (instrument_oid) where contains(point('ICRS', hsa.v_active_observation.ra, hsa.v_active_observation.dec), circle('ICRS', "+str(search_coords.ra.deg)+", " + str(search_coords.dec.deg) +", " + str(search_radius_arcsec) +"))=1 and hsa.instrument.instrument_name='"+str(instrument_name)+"'"
+            objectid_table = HSA.query_hsa_tap(querystring)
+
+            #download_data only accepts one observation_id so we need to loop over each observation_id
+            for tab_id in range(len(objectid_table)):
+                observation_id = str(objectid_table[tab_id]['observation_id'])
+                try: 
+                    HSA.download_data(observation_id=observation_id, retrieval_type='OBSERVATION', 
+                            instrument_name=instrument_name, product_level = "LEVEL2, LEVEL_2_5, LEVEL_3", download_dir = datadir)
+                
+                    #ok, now we have the tar files, need to read those into the right data structure
+                    #first untar
+                    path_to_file = f"{datadir}/{observation_id}.tar"
+                    
+                    object = tarfile.open(path_to_file, 'r')
+                    #there are a million files!!! how do I know which one I need?
+                    #only grab the files which have the final spectra in them = "HPSSPEC" in directory name
+                    #not all modes have a final spectrum (cubes?) 
+                    for member in object.getmembers():
+                         if "HPSSPEC"  in member.name: 
+                            path_to_final_dir = f'data/herschel/final_spectrum{observation_id}'
+                            object.extract(member, path = path_to_final_dir)
+
+                            for directory_name in os.listdir(path_to_final_dir):
+ 
+                                for fits_file_path in glob.glob(f"{path_to_final_dir}/{directory_name}/{observation_id}/level*/HPSSPEC*/herschel*/*"):
+                                    #open the fits file
+                                    hdulist = fits.open(fits_file_path) 
+                                
+                                    #convert final spectrum to pandas dataframe
+                                    df = pd.DataFrame(hdulist[1].data)
+                                    #There are multiple flux columns; figure out which flux column to use
+                                    #advice from https://www.cosmos.esa.int/documents/12133/996891/Product+decision+trees 
+                                    #is to use the flux coluimn with the most flux
+                                    max_flux = find_max_flux_column(df)
+                                    #use the corresponding uncertainty column
+                                    max_error =  max_flux.replace("Flux", "Error")
+
+                                    #convert to cgs units for saving and plotting
+                                    flux_Jy = df[max_flux].to_numpy() * u.Jy
+                                    wavelength = df.wave[0] * u.micrometer #single wavelength for conversion to cgs
+                                    flux_cgs = flux_Jy.to(u.erg / u.second / (u.centimeter**2) / u.hertz) * (const.c.to(u.angstrom/u.second)) / (wavelength.to(u.angstrom)**2)
+                                    flux_cgs = flux_cgs.to(u.erg / u.second / (u.centimeter**2) / u.angstrom)
+
+                                    flux_err_Jy = df[max_error].to_numpy() * u.Jy
+                                    flux_err_cgs = flux_err_Jy.to(u.erg / u.second / (u.centimeter**2) / u.hertz) * (const.c.to(u.angstrom/u.second)) / (wavelength.to(u.angstrom)**2)
+                                    flux_err_cgs = flux_err_cgs.to(u.erg / u.second / (u.centimeter**2) / u.angstrom)
+                                    
+                                    wave = df.wave.to_numpy() * u.micrometer
+                                    wave = wave.to(u.angstrom)
+                                    #build the df with this object's spectrum from this instrument
+                                    dfsingle = pd.DataFrame(dict(wave=[wave] , flux=[flux_cgs], err=[flux_err_cgs],
+                                                label=[stab["label"]],
+                                                objectid=[stab["objectid"]],
+                                                mission=["Herschel"],
+                                                instrument=[instrument_name],
+                                                filter=[df["band"][0]],
+                                                )).set_index(["objectid", "label", "filter", "mission"])
+                                    
+
+                                    df_spec.append(dfsingle)
+
+                except LoginError:
+                    print("This observation is proprietary, which might mean that it is calibration data")
+                except:
+                    print("Connection to the ESA archive broken")
+
+                #delete tar files
+                if delete_tarfiles:
+                    filename_tar = f"data/herschel/{objectid_table[tab_id]['observation_id']}.tar"
+                    print('filename_tar', filename_tar)
+                    if os.path.exists(filename_tar):
+                        print('removing tar file')
+                        os.remove(filename_tar)
+
+    return df_spec
+                    

--- a/spectroscopy/spectra_generator.md
+++ b/spectroscopy/spectra_generator.md
@@ -96,6 +96,7 @@ Andreas Faisst, Jessica Krick, Shoubaneh Hemmati, Troy Raen, Brigitta Sipőcz, D
 ## IMPORTS
 import sys
 import numpy as np
+import os
 
 import matplotlib.pyplot as plt
 import matplotlib as mpl
@@ -203,6 +204,102 @@ df_spec.append(df_spec_DEIMOS)
 ## Get Spitzer IRS Spectra
 df_spec_IRS = SpitzerIRS_get_spec(sample_table, search_radius_arcsec=1 , COMBINESPEC=False)
 df_spec.append(df_spec_IRS)
+
+```
+
+```python
+len(objectid_table)
+```
+
+```python
+for row in objectid_table:
+    print(type(row['observation_id']))
+    HSA.download_data(observation_id = row['observation_id'], retrieval_type='OBSERVATION', 
+                      instrument_name='PACS', download_dir = 'data/herschel')
+
+
+```
+
+```python
+a = 'test'
+type(a)
+```
+
+```python
+#minimum functional example
+from astroquery.esa.hsa import HSA
+
+test_table = HSA.query_hsa_tap("select top 10 observation_id from hsa.v_active_observation where "
+                  "contains(point('ICRS', hsa.v_active_observation.ra, hsa.v_active_observation.dec), "
+                  "circle('ICRS', 100.2417,9.895, 1.1))=1")
+
+for row in test_table:
+    print(str(row['observation_id']) ) #confirm that syntax is not the problem
+    try:
+        HSA.download_data(observation_id=str(row['observation_id']), retrieval_type='OBSERVATION', 
+                    instrument_name='PACS', download_dir = 'data/herschel')
+    except LoginError:
+        #there is some problem here with the observation_id which causes Herschel to think it is proprietary
+        #we just won't get this data, move on to the next observation
+        print("loginerror") 
+
+```
+
+```python
+## Herschel PACS & SPIRE (actually from ESA TAP)
+from astroquery.esa.hsa import HSA
+from astroquery.exceptions import LoginError
+
+## Initialize multi-index object:
+df_spec = MultiIndexDFObject()
+
+herschel_radius = 1.1  #units?
+for stab in sample_table:
+    search_coords = stab["coord"]
+    print("working on object", search_coords)
+    #first find the object ids from herschel
+    #docstring for query_hsa_tab doesn't say that it accepts an upload_table so do this one by one.
+    #this only grabs the first 2 observations, could consider changing that
+
+    #this works but returns both PACS and SPIRE which then download_data doesn't handle well
+    #objectid_table = HSA.query_hsa_tap("select top 2 observation_id from hsa.v_active_observation where "
+    #              "contains(point('ICRS', hsa.v_active_observation.ra, hsa.v_active_observation.dec), "
+    #              "circle('ICRS', "+str(search_coords.ra.deg)+", " + str(search_coords.dec.deg) +", " + str(herschel_radius) +"))=1")
+
+    for instrument_name in ['PACS', 'SPIRE']:
+        querystring = "select top 2 observation_id from hsa.v_active_observation join hsa.instrument using (instrument_oid) where contains(point('ICRS', hsa.v_active_observation.ra, hsa.v_active_observation.dec), circle('ICRS', "+str(search_coords.ra.deg)+", " + str(search_coords.dec.deg) +", " + str(herschel_radius) +"))=1 and hsa.instrument.instrument_name='"+str(instrument_name)+"'"
+        objectid_table = HSA.query_hsa_tap(querystring)
+
+        #for each observation_id
+         #download_data only accepts one observation_id
+        for tab_id in range(len(objectid_table)):
+            print(tab_id)
+            print(objectid_table[tab_id]['observation_id'])
+            HSA.download_data(observation_id=str(objectid_table[tab_id]['observation_id']), retrieval_type='OBSERVATION', 
+                        instrument_name=instrument_name, product_level = "LEVEL2, LEVEL_2_5, LEVEL_3", download_dir = 'data/herschel')
+        
+            #ok, now we have the tar files, need to read those into the right data structure
+            #there are a million files!!! how do I know which one I need?
+            #should be a HPSSPEC[B|R]/herschel.pacs.signal.PacsCentralSpectrum with a point source table???
+            #    https://www.cosmos.esa.int/documents/12133/996891/PACS+Spectrometer+Quick+Start+Guide
+            #once I figure out the file that has the data I want, try looking at mast_functions for 
+            #how to use specutils to read in the spectrum and add it to dataframe.
+
+            #and delete tar files
+            #filename_tar = f"data/herschel/{objectid_table[tab_id]['observation_id']}.tar"
+            #if os.path.exists(filename_tar):
+            #    os.remove(filename_tar)
+
+
+```
+
+```python
+    for tab_id in range(len(objectid_table)):
+        print(tab_id)
+        print(type(str(objectid_table[tab_id]['observation_id'])))
+        HSA.download_data(observation_id=str(objectid_table[1]['observation_id']), retrieval_type='OBSERVATION', 
+                      instrument_name='PACS', download_dir = 'data/herschel')
+
 
 ```
 


### PR DESCRIPTION
This new module downloads and extracts "reduced" Herschel spectroscopy for a set of sources.  It is completely functional, but not perfect.  Description of imperfections (with short rants included) below:

1. Some decisions had to be made as this is a complicated dataset with complicated sets of rules about when a final spectrum is generated and which fluxes of the many reported are the best to use for any given target.  

   -  only observations which produce a HPSSPEC directory are considered.  There seems to be no way to ascertain this in the archive search, so the code downloads all tar files for all observations and then checks to see if this directory exists.
  
   - source resolution matters, ie., recommendations for which reduced spectrum to use are based on wether or not it is a point source or how extended it is. I have followed the advice in https://www.cosmos.esa.int/documents/12133/996891/Product+decision+trees to use the flux column which has the largest sum.  It is beyond the scope of this notebook to calculate if the sources is extended in Herschel band or not.

   - The Herschel directory tree in the downloaded tar files is extensive, and there is no way to customize and only download the one file that I need, so there is a lot of code around tracking filenames and paths and searching paths for filenames.

   - The Herschel archive breaks the connection at some point (testing on Arp220 which has many observations > 50, will hit this error).  I cannot for the life of me figure out how to catch the specific exceptions, and have spent too long trying to do this. So I know that blanket exceptions are not good practice, but they are the only way I know how to get this to work.  I have opened an issue on this  both here (#282 ) and at astroquery (to try to fix this at the source).

   - I have written into the function an option to delete tar files after the spectrum is extracted.  

2. I re-numbered the sections to account for the fact that Herschel data is being accessed through the ESA archive and not IRSA as was originally suggested in the outline.  The use of astroquery's ESA module  made this module possible in an automated fashion from python, so it is not possible to switch to IRSA.  IRSA only houses an API (which may even just access the ESA API???).  

3. It works with the plotting function before Andreas's newest PR #281 , but probably needs to be checked for compatibility with new function.   I have opened an issue for this (#283 ).