### PR TITLE
Change kernel names generator -> collector

### DIFF
--- a/light_curves/light_curve_collector.md
+++ b/light_curves/light_curve_collector.md
@@ -6,9 +6,9 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.17.1
 kernelspec:
-  display_name: py-light_curve_generator
+  display_name: py-light_curve_collector
   language: python
-  name: py-light_curve_generator
+  name: py-light_curve_collector
 ---
 
 # Make Multi-Wavelength Light Curves Using Archival Data

--- a/spectroscopy/spectra_collector.md
+++ b/spectroscopy/spectra_collector.md
@@ -6,8 +6,8 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.17.2
 kernelspec:
-  name: py-spectra_generator
-  display_name: py-spectra_generator
+  name: py-spectra_collector
+  display_name: py-spectra_collector
   language: python
 ---
 


### PR DESCRIPTION
Follow up #460 
Caused by nasa-fornax/fornax-images/issues/49

Change kernel names generator -> collector in the two notebooks that were renamed in #460.