### PR TITLE
Ignore .hdf5 and .pth files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,12 +15,14 @@ cache/
 *.ecsv
 *.fits
 *.gzip
+*.hdf5
 *.jpg
 *.jpeg
 *.log
 *.parquet
 *.pdf
 *.png
+*.pth
 *.gz
 
 # Tests and reports


### PR DESCRIPTION
Two more data file formats we should be ignoring.