### PR TITLE
Reduce dependencies related to lsdb

### DIFF
--- a/crossmatch/requirements_ztf_ps1_crossmatch.txt
+++ b/crossmatch/requirements_ztf_ps1_crossmatch.txt
@@ -4,5 +4,5 @@ matplotlib
 # >=0.6.5 for ConeSearch import. https://github.com/nasa-fornax/fornax-demo-notebooks/issues/523
 lsdb>=0.6.5
 dask
-# Read files from AWS S3.
+# Required by lsdb to read files from AWS S3, revise when lsdb[s3fs] is supported by required minimum version.
 s3fs

--- a/light_curves/requirements_light_curve_collector.txt
+++ b/light_curves/requirements_light_curve_collector.txt
@@ -16,7 +16,7 @@ lightkurve
 alerce
 # >=0.6.2 for improved s3 read speed.
 lsdb>=0.6.2
-# Read files from AWS S3.
+# Required by lsdb to read files from AWS S3, revise when lsdb[s3fs] is supported by required minimum version.
 s3fs
 # We use distributed in this notebook, but installing any dask would make the [dataframe] extras required by dependencies for other notebooks.
 # It feels to be the cleanest solution to add the dependency here as we don't directly use it elsewhere.


### PR DESCRIPTION
Resolves #548

- Require lsdb and s3fs instead of lsdb[full]
- Remove obsolete dependency universal_pathlib