### PR TITLE
Stop CircleCI from running on push to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,4 +43,8 @@ workflows:
   version: 2
   build-and-docs:
     jobs:
-      - build-docs
+      - build-docs:
+          filters:
+            branches:
+              ignore:
+                - main


### PR DESCRIPTION
This job is redundant with GHA.