### PR TITLE
remove unused code

### DIFF
--- a/light_curves/code_src/data_structures.py
+++ b/light_curves/code_src/data_structures.py
@@ -1,7 +1,5 @@
 # setup to store the light curves in a data structure
 import pandas as pd
-from astropy.table import vstack
-from astropy.timeseries import TimeSeries
 
 
 class MultiIndexDFObject:


### PR DESCRIPTION
This PR removes unused constructs (MultibandTimeSeries class and MultiIndexDFObject.combine_Samples() method from light_curves/code_src/data_structures.py.  It also drops now-unused imports (e.g., TimeSeries/vstack).  No new functionality is added

Additionally AI ran some tests to look for other unused functions in the light_curves directory and found nothing that could be safely removed.  I did not check this manually because it will take too long, and it's something we check in tech reviews, so shouldn't be a problem. 

This will close #561 