### PR TITLE
cleaning up build your own sample and bugfix wise function

### DIFF
--- a/light_curves/code_src/sample_selection.py
+++ b/light_curves/code_src/sample_selection.py
@@ -654,3 +654,63 @@ def clean_sample(coords_list, labels_list, *, consolidate_nearby_objects=True, v
         print(f'Object sample size, after duplicates removal: {len(uniqued_table)}')
 
     return uniqued_table
+def validate_sample_table(tbl):
+    """
+    Validate the structure of a user-supplied ``sample_table``.
+
+    This function verifies that the supplied object is an
+    ``astropy.table.Table`` and that it contains the required
+    columns (``coord``, ``objectid``, ``label``). It checks that
+    ``coord`` entries are ``SkyCoord`` objects, that ``objectid``
+    values are integers, unique, and sequential starting at 1, and
+    that ``label`` contains strings. Informative exceptions are
+    raised if validation fails.
+    
+    Parameters
+    ----------
+    tbl : astropy.table.Table
+        Table to validate. Must represent a cleaned source sample
+        with one row per sky object.
+
+    Raises
+    ------
+    ValueError
+        If required columns are missing or ``objectid`` values are
+        non-unique or non-sequential.
+    TypeError
+        If column types are not as expected (e.g., ``coord`` not
+        containing ``SkyCoord`` objects).
+
+    """
+    from astropy.coordinates import SkyCoord
+    
+    # Check that tbl is an Astropy Table
+    if not isinstance(tbl, Table):
+        raise TypeError("Input must be an astropy.table.Table instance.")
+
+
+    required = {"coord", "objectid", "label"}
+    missing = required - set(tbl.colnames)
+    if missing:
+        raise ValueError(f"sample_table is missing required columns: {missing}")
+
+    # coord type check
+    if not all(isinstance(c, SkyCoord) for c in tbl["coord"]):
+        raise TypeError("Column 'coord' must contain astropy.coordinates.SkyCoord objects.")
+
+    # objectid checks
+    obj = tbl["objectid"]
+    if not (obj.dtype.kind in ("i", "u")):
+        raise TypeError("Column 'objectid' must contain integers.")
+
+    if len(set(obj)) != len(obj):
+        raise ValueError("Column 'objectid' must contain unique values.")
+
+    if sorted(obj) != list(range(1, len(obj) + 1)):
+        raise ValueError("objectid must start at 1 and increment without gaps.")
+
+    # label check
+    if not all(isinstance(x, str) for x in tbl["label"]):
+        raise TypeError("Column 'label' must contain strings.")
+
+    print("sample_table format is valid.")

--- a/light_curves/code_src/wise_functions.py
+++ b/light_curves/code_src/wise_functions.py
@@ -227,7 +227,7 @@ def load_lightcurves(locations, radius, bandlist):
         match_df["object_ilocs"] = object_ilocs
         match_df = match_df.set_index("object_ilocs").join(
             locs_df.reset_index(drop=True),
-            rsuffix="_obj"             # prevents ra/dec collisions
+            rsuffix="_obj"             # prevent name collisions if sample_table has extra columns
         )
 
         wise_df_list.append(match_df)

--- a/light_curves/light_curve_collector.md
+++ b/light_curves/light_curve_collector.md
@@ -155,74 +155,7 @@ or
 You can use [astropy's read](https://docs.astropy.org/en/stable/io/ascii/read.html) function to read in an input table
 to an [astropy table](https://docs.astropy.org/en/stable/table/)
 
-If you want to build your own sample_table, your table must contain one row per source and include exactly three required pieces of information: a coord column holding an astropy.coordinates.SkyCoord position for each object, a unique integer objectid, and a label column giving a short string describing that source’s origin (e.g., literature reference, sample name, or provenance tag). 
-
-```{code-cell} ipython3
----
-jupyter:
-  source_hidden: true
----
-def validate_sample_table(tbl):
-    """
-    Validate the structure of a user-supplied ``sample_table``.
-
-    This function verifies that the supplied object is an
-    ``astropy.table.Table`` and that it contains the required
-    columns (``coord``, ``objectid``, ``label``). It checks that
-    ``coord`` entries are ``SkyCoord`` objects, that ``objectid``
-    values are integers, unique, and sequential starting at 1, and
-    that ``label`` contains strings. Informative exceptions are
-    raised if validation fails.
-    
-    Parameters
-    ----------
-    tbl : astropy.table.Table
-        Table to validate. Must represent a cleaned source sample
-        with one row per sky object.
-
-    Raises
-    ------
-    ValueError
-        If required columns are missing or ``objectid`` values are
-        non-unique or non-sequential.
-    TypeError
-        If column types are not as expected (e.g., ``coord`` not
-        containing ``SkyCoord`` objects).
-
-    """
-    from astropy.coordinates import SkyCoord
-    
-    # Check that tbl is an Astropy Table
-    if not isinstance(tbl, Table):
-        raise TypeError("Input must be an astropy.table.Table instance.")
-
-
-    required = {"coord", "objectid", "label"}
-    missing = required - set(tbl.colnames)
-    if missing:
-        raise ValueError(f"sample_table is missing required columns: {missing}")
-
-    # coord type check
-    if not all(isinstance(c, SkyCoord) for c in tbl["coord"]):
-        raise TypeError("Column 'coord' must contain astropy.coordinates.SkyCoord objects.")
-
-    # objectid checks
-    obj = tbl["objectid"]
-    if not (obj.dtype.kind in ("i", "u")):
-        raise TypeError("Column 'objectid' must contain integers.")
-
-    if len(set(obj)) != len(obj):
-        raise ValueError("Column 'objectid' must contain unique values.")
-
-    if sorted(obj) != list(range(1, len(obj) + 1)):
-        raise ValueError("objectid must start at 1 and increment without gaps.")
-
-    # label check
-    if not all(isinstance(x, str) for x in tbl["label"]):
-        raise TypeError("Column 'label' must contain strings.")
-
-    print("sample_table format is valid.")
-```
+If you want to build your own sample_table, your table must contain one row per source and include exactly three required pieces of information: a coord column holding an astropy.coordinates.SkyCoord position for each object, a unique integer objectid, and a label column giving a short string describing that source’s origin (e.g., literature reference, sample name, or provenance tag).
 
 ```{code-cell} ipython3
 # Run this cell if you build your own sample to validate that it has the 


### PR DESCRIPTION
This will close #512 

This update adds a new internal validation utility for user-supplied sample_table objects and fixes a column-collision bug in the WISE light-curve loader.
Changes:
1. Added validate_sample_table() and surrounding explanatory text
- Introduces a structural validator ensuring that any user-constructed sample table is an astropy.table.Table with the required coord, objectid, and label columns and correct data types.
- Included inline documentation to guide users building their own samples.
2. Fixed column-overlap bug in load_lightcurves()
- The join between WISE detections and object metadata produced overlapping ra/dec columns and raised a ValueError.
Added rsuffix="_obj" to the join operation to avoid collision and preserve both coordinate sets safely.
