### PR TITLE
MAINT: adding boto3 to the requirements

### DIFF
--- a/spectroscopy/requirements_spectra_collector.txt
+++ b/spectroscopy/requirements_spectra_collector.txt
@@ -8,13 +8,16 @@ pandas
 # compatible yet
 # sparclclient
 astropy
-# due to Spectrum1D rename to Spectrum and an internap spectutils bug
+# pin is due to Spectrum1D rename to Spectrum and an internap spectutils bug
 specutils>=1.20.1
-# due to astroquery.mast fixes
-astroquery>=0.4.11.dev0
+# pin is due to astroquery.mast fixes
+astroquery>=0.4.11
+# as astroquery optional dependencies `mast` relies on
+boto3
+botocore
 fsspec
 # Avoid the poor performance and timeouts described here:
 # https://github.com/dask/dask/issues/10276
-s3fs[boto3]>0.6.0
+s3fs>0.6.0
 requests
 pyvo


### PR DESCRIPTION
This is to resolve #571 as s3fs changed their optional extras and now we cannot rely on it to install boto3 (we don't directly use it, but via astroquery.mast)