### PR TITLE
MAINT: limit lsdb version as we know API breakage is coming

### DIFF
--- a/crossmatch/requirements_ztf_ps1_crossmatch.txt
+++ b/crossmatch/requirements_ztf_ps1_crossmatch.txt
@@ -2,7 +2,8 @@ astropy
 pandas
 matplotlib
 # >=0.6.5 for ConeSearch import. https://github.com/nasa-fornax/fornax-demo-notebooks/issues/523
-lsdb>=0.6.5
+# Upper limit <0.8 is for instant workaround of coming incompatibility https://github.com/nasa-fornax/fornax-demo-notebooks/issues/587
+lsdb>=0.6.5,<0.8
 dask
 # Required by lsdb to read files from AWS S3, revise when lsdb[s3fs] is supported by required minimum version.
 s3fs

--- a/light_curves/requirements_light_curve_collector.txt
+++ b/light_curves/requirements_light_curve_collector.txt
@@ -15,7 +15,8 @@ acstools
 lightkurve
 alerce
 # >=0.6.2 for improved s3 read speed.
-lsdb>=0.6.2
+# Upper limit <0.8 is for instant workaround of coming incompatibility https://github.com/nasa-fornax/fornax-demo-notebooks/issues/587
+lsdb>=0.6.2,<0.8
 # Required by lsdb to read files from AWS S3, revise when lsdb[s3fs] is supported by required minimum version.
 s3fs
 # We use distributed in this notebook, but installing any dask would make the [dataframe] extras required by dependencies for other notebooks.


### PR DESCRIPTION
This is to add an instant workaround for the incompatibilities coming in the next release. For context and long term solution, see https://github.com/nasa-fornax/fornax-demo-notebooks/issues/587