### PR TITLE
Catch the correct `TimeoutError`

### DIFF
--- a/spectroscopy/code_src/sdss_functions.py
+++ b/spectroscopy/code_src/sdss_functions.py
@@ -1,4 +1,5 @@
 import astropy.units as u
+import astroquery.exceptions
 import numpy as np
 import pandas as pd
 import requests
@@ -58,7 +59,7 @@ def SDSS_get_spec(sample_table, search_radius_arcsec, data_release):
         # Catch service errors https://github.com/nasa-fornax/fornax-demo-notebooks/issues/437
         try:
             sp = SDSS.get_spectra(matches=xid, show_progress=True, data_release=data_release)
-        except (KeyError, ReadTimeout):
+        except (KeyError, astroquery.exceptions.TimeoutError):
             warnings.warn(
                 f"SDSS get_spectra failed for source {stab['label']}; skipping.",
                 RuntimeWarning,


### PR DESCRIPTION
Fixes https://github.com/nasa-fornax/fornax-demo-notebooks/pull/590#discussion_r2633380829. The relevant traceback is https://github.com/nasa-fornax/fornax-demo-notebooks/issues/437#issuecomment-3377958977. Initially I assumed this was python's built-in `TimeoutError` because there's no hint in the traceback that it's anything else. But I looked into the astroquery source code starting from where the error is raised here: https://github.com/astropy/astroquery/blob/5eceae1aa1b8545f54fd8f8b46f25d82526fb92a/astroquery/utils/commons.py#L335 and learned that it's importing it's own custom `TimeoutError` and raising that.