### PR TITLE
Euclid function now uses query_ssa() instead of query_region()

### DIFF
--- a/spectroscopy/code_src/euclid_functions.py
+++ b/spectroscopy/code_src/euclid_functions.py
@@ -100,8 +100,8 @@ def euclid_get_spec(sample_table, search_radius_arcsec, verbose=True):
         ssa_coords = SkyCoord(ssa_result["s_ra"], ssa_result["s_dec"], unit=u.deg)
 
         # Compute separations and choose the closest SSA row
-        seps = coord.separation(ssa_coords)
-        closest_idx = int(np.argmin(seps))
+        separations = coord.separation(ssa_coords)
+        closest_idx = int(np.argmin(separations))
         row = ssa_result[closest_idx]
  
         # Read the spectrum file from the SSA access URL


### PR DESCRIPTION
This PR updates euclid_get_spec() to retrieve Euclid NISP 1D spectra via IRSA’s Simple Spectral Access (SSA) service instead of the previous TAP-based catalog and association-table workflow. The function now queries the Euclid SSA collection directly, all other functionality is not changed.  

I have confirmed that the function returns the same spectrum for the one "TestEuclid" source which previously had returned a spectrum.  

This will close #513 