### PR TITLE
Add back in DESI with sparclclient

### DIFF
--- a/spectroscopy/code_src/desi_functions.py
+++ b/spectroscopy/code_src/desi_functions.py
@@ -5,7 +5,7 @@ from astropy import nddata
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
 from sparcl.client import SparclClient
-from specutils import Spectrum1D
+from specutils import Spectrum
 
 from data_structures_spec import MultiIndexDFObject
 
@@ -38,7 +38,7 @@ def DESIBOSS_get_spec(sample_table, search_radius_arcsec):
     for stab in sample_table:
 
         # Search
-        data_releases = ['DESI-EDR', 'BOSS-DR16']
+        data_releases = ['DESI-EDR', 'BOSS-DR17']
 
         search_coords = stab["coord"]
         dra = (search_radius_arcsec * u.arcsec).to(u.degree)
@@ -66,7 +66,7 @@ def DESIBOSS_get_spec(sample_table, search_radius_arcsec):
         inc = ['sparcl_id', 'specid', 'data_release', 'redshift', 'flux',
                'wavelength', 'model', 'ivar', 'mask', 'spectype', 'ra', 'dec']
         results_I = client.retrieve(uuid_list=found_I.ids, include=inc)
-        specs = [Spectrum1D(spectral_axis=r.wavelength * u.AA,
+        specs = [Spectrum(spectral_axis=r.wavelength * u.AA,
                             flux=np.array(r.flux) * 10**-17 * u.Unit('erg cm-2 s-1 AA-1'),
                             uncertainty=nddata.InverseVariance(np.array(r.ivar)),
                             redshift=r.redshift,

--- a/spectroscopy/requirements_spectra_collector.txt
+++ b/spectroscopy/requirements_spectra_collector.txt
@@ -4,9 +4,7 @@
 numpy
 matplotlib
 pandas
-# Right now we don't include DESI by default as sparclclient is not numpy2
-# compatible yet
-# sparclclient
+sparclclient
 astropy
 # pin is due to Spectrum1D rename to Spectrum and an internap spectutils bug
 specutils>=1.20.1

--- a/spectroscopy/spectra_collector.md
+++ b/spectroscopy/spectra_collector.md
@@ -4,13 +4,11 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.17.2
+    jupytext_version: 1.18.1
 kernelspec:
   name: py-spectra_collector
   display_name: py-spectra_collector
   language: python
-execution:
-  timeout: 1200
 ---
 
 # Extract Multi-Wavelength Spectroscopy from Archival Data
@@ -58,7 +56,7 @@ this to work, the `specutils` functions may have to be update or a wrapper has t
 | MAST    | HST*         | Slitless spectra would need reduction and extraction. There are some reduced slit spectra from COS in the Hubble Archive | `astroquery.mast` | Implemented using `astroquery.mast` |
 | MAST    | JWST*        | Reduced slit MSA and Slit spectra that can be queried | `astroquery.mast` | Implemented using `astroquery.mast` |
 | SDSS    | SDSS optical| Optical spectra that are reduced | [Sky Server](https://skyserver.sdss.org/dr18/SearchTools) or `astroquery.sdss` (preferred) | Implemented using `astroquery.sdss`. |
-| DESI    | DESI*        | Optical spectra | [DESI public data release](https://data.desi.lbl.gov/public/) | Implemented with `SPARCL` library.  Currently commented out because `SPARCL` library is incompatible with numpy > 2 which we need for other modules|
+| DESI    | DESI*        | Optical spectra | [DESI public data release](https://data.desi.lbl.gov/public/) | Implemented with `SPARCL` library.  |
 | BOSS    | BOSS*        | Optical spectra | [BOSS webpage (part of SDSS)](https://www.sdss4.org/surveys/boss/) | Implemented with `SPARCL` library together with DESI |
 | HEASARC | None        | Could link to Chandra observations to check AGN occurrence. | `astroquery.heasarc` | More thoughts on how to include scientifically.   |
 
@@ -111,7 +109,7 @@ from astropy.utils.data import conf
 
 sys.path.append('code_src/')
 from data_structures_spec import MultiIndexDFObject
-#from desi_functions import DESIBOSS_get_spec
+from desi_functions import DESIBOSS_get_spec
 from herschel_functions import Herschel_get_spec
 from keck_functions import KeckDEIMOS_get_spec
 from mast_functions import HST_get_spec, JWST_get_spec
@@ -303,8 +301,8 @@ The DESI search is currently commented out because `SPARCL` is not compatible wi
 
 ```{code-cell} ipython3
 ## Get DESI and BOSS spectra with SPARCL
-#df_spec_DESIBOSS = DESIBOSS_get_spec(sample_table, search_radius_arcsec=5)
-#df_spec.append(df_spec_DESIBOSS)
+df_spec_DESIBOSS = DESIBOSS_get_spec(sample_table, search_radius_arcsec=5)
+df_spec.append(df_spec_DESIBOSS)
 ```
 
 ## 3. Make plots of luminosity as a function of time


### PR DESCRIPTION

Re-instating DESI spectroscopy search through sparclclient since that is now compatible with numpy2.  At the same time I have updated Spectrum1D to Spectrum.  All appears functional.

This will close #406 