### PR TITLE
Convert Observations to mast missions in spectroscopy/code_src/mast_functions.py

### DIFF
--- a/spectroscopy/code_src/mast_functions.py
+++ b/spectroscopy/code_src/mast_functions.py
@@ -414,14 +414,8 @@ def HST_get_spec(sample_table, search_radius_arcsec, datadir, verbose= True,
             data_products_list, 
             type='science',         # only science products
             extension="fits",
+            file_suffix = "SX1"     # calibrated 1D spectra
         )
-
-        # Manual filter on suffix to get calibrated 1D spectra
-        keys = np.asarray(filtered["product_key"]).astype(str)
-        suffix_mask = (
-            np.char.endswith(keys, "_sx1.fits") 
-        )
-        filtered = filtered[suffix_mask]
 
         if verbose:
             print("Number of files to download: {}".format(len(filtered)))


### PR DESCRIPTION
closes #527 (hopefully)

I am not getting timeout errors now with MastMissions, but I have only run it a handful of times.  

Conversion to MastMissions class means a few other things changed, but the functionality is the same.  I took some things out of the long hst_get_spec function and made them their own functions (remove warnings about units that astropy was throwing and also reading the spectra files).