### PR TITLE
MAINT: remove upper limit on fsspec

### DIFF
--- a/light_curves/requirements_light_curve_collector.txt
+++ b/light_curves/requirements_light_curve_collector.txt
@@ -21,8 +21,8 @@ lsdb>=0.6.2,<0.8
 cdshealpix<0.8
 # Required by lsdb to read files from AWS S3, revise when lsdb[s3fs] is supported by required minimum version.
 s3fs
-# Required by lsdb, and limiting version to work around known bug/regression https://github.com/astronomy-commons/lsdb/issues/1201
-fsspec<2025.12
+# Required by lsdb, a few versions are known to cause issues
+fsspec!=2025.12,!=2026.1
 # We use distributed in this notebook, but installing any dask would make the [dataframe] extras required by dependencies for other notebooks.
 # It feels to be the cleanest solution to add the dependency here as we don't directly use it elsewhere.
 dask[distributed,dataframe]


### PR DESCRIPTION
Upstream has been fixed, so we can update our pin. Most lsdb/hats/nested-pandas will have additional pins for it, but at this point we can trust that the solver will take care of it.