### PR TITLE
Copilot/remove astrophysics default image

### DIFF
--- a/light_curves/ML_AGNzoo.md
+++ b/light_curves/ML_AGNzoo.md
@@ -29,7 +29,7 @@ We use manifold learning and dimensionality reduction to learn the distribution 
 
 ### Runtime
 
-As of 2024 September, this notebook takes ~160s to run to completion (after installs and imports) on Fornax using the ‘Astrophysics Default Image’ environment and the ‘Large’ server with 16GB RAM/ 4CPU.
+As of 2024 September, this notebook takes ~160s to run to completion (after installs and imports) on Fornax using a server with 16GB RAM/ 4CPU.
 
 ## Imports
 

--- a/light_curves/light_curve_classifier.md
+++ b/light_curves/light_curve_classifier.md
@@ -55,7 +55,7 @@ Trained classifiers as well as estimates of their accuracy and plots of confusio
 
 ### Runtime
 
-As of 2024 August, this notebook takes ~170s to run to completion on Fornax using the 'Astrophysics Default Image' and the 'Large' server with 16GB RAM/ 4CPU.
+As of 2024 August, this notebook takes ~170s to run to completion on Fornax using a server with 16GB RAM/ 4CPU.
 
 ## Imports
 

--- a/light_curves/light_curve_collector.md
+++ b/light_curves/light_curve_collector.md
@@ -45,7 +45,7 @@ By the end of this tutorial, you will be able to:
 
 ### Runtime
 
-- As of 2025 May, this notebook takes ~1000s (17 min.) to run to completion on Fornax using the ‘Astrophysics Default Image’ and the ‘Large’ server with 64GB RAM/ 16CPU.
+- As of 2025 May, this notebook takes ~1000s (17 min.) to run to completion on Fornax using a server with 64GB RAM/ 16CPU.
 
 ## Imports
 


### PR DESCRIPTION
The "Astrophysics Default Image" environment no longer exists. Tutorial notebooks still referenced it in runtime sections, causing confusion.

Changes

Updated runtime documentation in 3 tutorial notebooks to remove obsolete image references:

light_curves/ML_AGNzoo.md - Line 32
light_curves/light_curve_classifier.md - Line 58
light_curves/light_curve_collector.md - Line 48
Before:

As of 2024 August, this notebook takes ~170s to run to completion on Fornax using the 'Astrophysics Default Image' and the 'Large' server with 16GB RAM/ 4CPU.

After:

As of 2024 August, this notebook takes ~170s to run to completion on Fornax using a server with 16GB RAM/ 4CPU.
Server specifications and runtime estimates remain unchanged.



Note: copilot did this entirePR, so please take out your sharpest pencils for review.  I am still working out the process for using copilot to work smoothly for PRs. 

will close #617 