### PR TITLE
CI: skip execution for untouched notebooks

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -44,17 +44,17 @@ commands =
     bash -c "grep md deployed_notebooks_manifest.in | xargs grep name: | awk  -F : '{print $1}' | uniq > all_tutorials"
 
     # Make a list of the tutorials changed, we only need this in CI. Also deal with grep's non-zero exit code.
-    bash -c 'if [[ $CI == true ]]; then git fetch origin main --depth=1; git diff origin/main --name-only | grep ".md" || true; fi > changed_tutorials'
+    bash -c 'if [[ $CI == true ]]; then git fetch origin main --depth=1; git diff origin/main --name-only | (grep ".md" || true); fi > changed_tutorials'
 
     # We need to override the kernelspec name field until
     # https://github.com/jupyter-book/mystmd/issues/2302 is resolved
     buildhtml: bash -c "cat all_tutorials | xargs grep name: | awk  -F : '{print $1}' | uniq | xargs -n 1 sed -i -Ee 's|(^\s*)(name:)(.*)|\1name: python3|g'"
 
     # We don't want to execute in rendering the ones we ignore for testing
-    buildhtml: bash -c 'grep -f ignore_testing all_tutorials || true > ignore_execute'
+    buildhtml: bash -c '(grep -f ignore_testing all_tutorials || true) > ignore_execute'
 
     # On CircleCI rendering preview, we also don't want to execute anything that hasn't been modified
-    buildhtml: bash -c 'if [[ $CIRCLECI == true ]]; then grep -vf changed_tutorials all_tutorials || true >> ignore_execute; fi'
+    buildhtml: bash -c 'if [[ $CIRCLECI == true ]]; then (grep -vf changed_tutorials all_tutorials || true) >> ignore_execute; fi'
 
     # sed -i needs a bit of hacky conditional on ubuntu to cover the case of an empty ignore
     buildhtml: bash -c 'if [ -s ignore_execute ]; then for name in $(cat ignore_execute | sort| uniq); do if [ -z "$(head -n 20 ${name}| grep execute:)" ]; then sed -i -e "s|kernelspec:|execute:\n  skip: true\nkernelspec:|g" ${name}; fi; done;fi'


### PR DESCRIPTION
Improvements to the CI config, most of this is already been tested and used for the IRSA notebooks.

resolves #325 and resolves #335 and also closes #355