### PR TITLE
MAINT: making sure --strict is errors out on missing references

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -11,6 +11,8 @@ project:
   settings:
     output_matplotlib_strings: remove
   error_rules:
+     - rule: reference-target-resolves
+       severity: error
      - rule: link-resolves
        severity: ignore
        keys:


### PR DESCRIPTION
We should error out on missing/broken references