### PR TITLE
MAINT: Adding licence to the rendered pages

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -6,7 +6,9 @@ project:
   keywords: [astronomy]
   authors: [Fornax developers and scientists]
   github: https://github.com/nasa-fornax/fornax-demo-notebooks
-  license: BSD-3-Clause
+  license:
+    id: BSD-3-Clause
+    url: https://github.com/nasa-fornax/fornax-demo-notebooks/blob/main/LICENSE
   references:
     fornax-docs: https://docs.fornax.sciencecloud.nasa.gov
   settings:


### PR DESCRIPTION
This is to include what we have currently.

Revising if this is the most appropriate licence or we should instead dual licence the content with e.g. CC-BY-4 and leaving the code as BSD-3 is a separate question.