### PR TITLE
MAINT: switchin linking to paper abstracts rather than pdf

### DIFF
--- a/light_curves/ML_AGNzoo.md
+++ b/light_curves/ML_AGNzoo.md
@@ -23,9 +23,17 @@ By the end of this tutorial, you will:
 
 ## Introduction
 
-Active Galactic Nuclei (AGNs), some of the most powerful sources in the universe, emit a broad range of electromagnetic radiation, from radio waves to gamma rays. Consequently, there is a wide variety of AGN labels depending on the identification/selection scheme and the presence or absence of certain emissions (e.g., Radio loud/quiet, Quasars, Blazars, Seiferts, Changing looks). According to the unified model, this zoo of labels we see depend on a limited number of parameters, namely the viewing angle, the accretion rate, presence or lack of jets, and perhaps the properties of the host/environment (e.g., [Padovani et al. 2017](https://arxiv.org/abs/1707.07134)). Here, we collect archival photometry and labels from the literature to compare how some of these different labels/selection schemes compare.
+Active Galactic Nuclei (AGNs), some of the most powerful sources in the universe, emit a broad range of electromagnetic radiation, from radio waves to gamma rays.
+Consequently, there is a wide variety of AGN labels depending on the identification/selection scheme and the presence or absence of certain emissions (e.g., Radio loud/quiet, Quasars, Blazars, Seiferts, Changing looks).
+According to the unified model, this zoo of labels we see depend on a limited number of parameters, namely the viewing angle, the accretion rate, presence or lack of jets, and perhaps the properties of the host/environment (e.g., [Padovani et al. 2017](https://arxiv.org/abs/1707.07134)).
+Here, we collect archival photometry and labels from the literature to compare how some of these different labels/selection schemes compare.
 
-We use manifold learning and dimensionality reduction to learn the distribution of AGN lightcurves observed with different facilities. We mostly focus on UMAP ([Uniform Manifold Approximation and Projection, McInnes 2020](https://arxiv.org/pdf/1802.03426.pdf)) but also show SOM ([Self organizing Map, Kohonen 1990](https://ieeexplore.ieee.org/document/58325)) examples. The reduced 2D projections from these two unsupervised ML techniques reveal similarities and overlaps of different selection techniques. Coloring the projections with various statistical physical properties (e.g., mean brightness, fractional lightcurve variation) is informative of correlations of the selections technique with physics such as AGN variability. Using different parts of the EM in training (or in building the initial higher dimensional manifold) demonstrates how much information if any is in that part of the data for each labeling scheme, for example whether with ZTF optical light curves alone, we can identify sources with variability in WISE near IR bands. These techniques also have a potential for identifying targets of a specific class or characteristic for future follow up observations.
+We use manifold learning and dimensionality reduction to learn the distribution of AGN lightcurves observed with different facilities.
+We mostly focus on UMAP ([Uniform Manifold Approximation and Projection, McInnes 2020](https://arxiv.org/pdf/1802.03426.pdf)) but also show SOM ([Self organizing Map, Kohonen 1990](https://ieeexplore.ieee.org/document/58325)) examples.
+The reduced 2D projections from these two unsupervised ML techniques reveal similarities and overlaps of different selection techniques.
+Coloring the projections with various statistical physical properties (e.g., mean brightness, fractional lightcurve variation) is informative of correlations of the selections technique with physics such as AGN variability.
+Using different parts of the EM in training (or in building the initial higher dimensional manifold) demonstrates how much information if any is in that part of the data for each labeling scheme, for example whether with ZTF optical light curves alone, we can identify sources with variability in WISE near IR bands.
+These techniques also have a potential for identifying targets of a specific class or characteristic for future follow up observations.
 
 ### Runtime
 
@@ -33,7 +41,8 @@ As of 2024 September, this notebook takes ~160s to run to completion (after inst
 
 ## Imports
 
-Here are the libraries used in this network. They are also mostly mentioned in the requirements in case you don't have them installed.
+Here are the libraries used in this network.
+They are also mostly mentioned in the requirements in case you don't have them installed.
 - *sys* and *os* to handle file names, paths, and directories
 - *numpy*  and *pandas* to handle array functions
 - *matplotlib* *pyplot* and *cm* for plotting data

--- a/light_curves/light_curve_collector.md
+++ b/light_curves/light_curve_collector.md
@@ -23,13 +23,26 @@ By the end of this tutorial, you will be able to:
 
 ## Introduction
 
- * A user has a sample of interesting targets for which they would like to see a plot of available archival light curves.  We start with a small set of changing look AGN from Yang et al., 2018, which are automatically downloaded. Changing look AGN are cases where the broad emission lines appear or disappear (and not just that the flux is variable).
+ * A user has a sample of interesting targets for which they would like to see a plot of available archival light curves.
+ We start with a small set of changing look AGN from Yang et al., 2018, which are automatically downloaded.
+ Changing look AGN are cases where the broad emission lines appear or disappear (and not just that the flux is variable).
 
- * We model light curve plots after van Velzen et al. 2021.  We search through a curated list of time-domain NASA holdings as well as non-NASA sources.  HEASARC catalogs used are Fermi and Beppo-Sax, IRSA catalogs used are ZTF and WISE, and MAST catalogs used are Pan-STARRS, TESS, Kepler, and K2.  Non-NASA sources are Gaia and IceCube. This list is generalized enough to include many types of targets to make this notebook interesting for many types of science.  All of these time-domain archives are searched in an automated and efficient fashion using astroquery, pyvo, pyarrow or APIs.
+ * We model light curve plots after van Velzen et al. 2021.
+ We search through a curated list of time-domain NASA holdings as well as non-NASA sources.
+ HEASARC catalogs used are Fermi and Beppo-Sax, IRSA catalogs used are ZTF and WISE, and MAST catalogs used are Pan-STARRS, TESS, Kepler, and K2.
+ Non-NASA sources are Gaia and IceCube.
+ This list is generalized enough to include many types of targets to make this notebook interesting for many types of science.
+ All of these time-domain archives are searched in an automated and efficient fashion using astroquery, pyvo, pyarrow or APIs.
 
- * Light curve data storage is a tricky problem.  Currently we are using a MultiIndex Pandas dataframe, as the best existing choice for right now.  One downside is that we need to manually track the units of flux and time instead of relying on an astropy storage scheme which would be able to do some of the units worrying for us (even astropy can't do all magnitude to flux conversions).  Astropy does not currently have a good option for multi-band light curve storage.
+ * Light curve data storage is a tricky problem.
+ Currently we are using a MultiIndex Pandas dataframe, as the best existing choice for right now.
+ One downside is that we need to manually track the units of flux and time instead of relying on an astropy storage scheme which would be able to do some of the units worrying for us (even astropy can't do all magnitude to flux conversions).
+ Astropy does not currently have a good option for multi-band light curve storage.
 
- * This notebook walks through the individual steps required to collect the targets and their light curves and create figures. It also shows how to speed up the collection of light curves using python's `multiprocessing`. This is expected to be sufficient for up to ~500 targets. For a larger number of targets, consider using the bash script demonstrated in the neighboring notebook [scale_up](scale_up.md).
+ * This notebook walks through the individual steps required to collect the targets and their light curves and create figures.
+ It also shows how to speed up the collection of light curves using python's `multiprocessing`.
+ This is expected to be sufficient for up to ~500 targets.
+ For a larger number of targets, consider using the bash script demonstrated in the neighboring notebook [scale_up](scale_up.md).
 
  * ML work using these time-series light curves is in two neighboring notebooks: [ML_AGNzoo](ML_AGNzoo.md) and [light_curve_classifier](light_curve_classifier.md).
 


### PR DESCRIPTION
I also cut up the paragraps to be on multiple lines, so we have more sensible diffs in the future.

(the pdf links were failing CI in the latest run, so I try linking to the abs instead. Ultimately I think we should instead link to their ADS DOIs as those will render really nicely)