### PR TITLE
Fix spectra collector dependencies

### DIFF
--- a/spectroscopy/requirements_spectra_collector.txt
+++ b/spectroscopy/requirements_spectra_collector.txt
@@ -4,7 +4,7 @@
 numpy
 matplotlib
 pandas
-sparclclient>=1.2.7
+sparclclient>=1.2.8
 astropy
 # pin is due to Spectrum1D rename to Spectrum and an internap spectutils bug
 specutils>=1.20.1


### PR DESCRIPTION
Fixes #643 

This is currently doing the minimum necessary for this notebook, which is to pin sparclclient>=1.2.7. That still allows numpy v1.

Alternate options would be to either pin sparclclient>=1.2.8 (which would automatically require numpy>=2), or to unpin sparclclient and pin numpy>=2 instead. Happy to do either if you'd prefer, @bsipocz.