### PR TITLE
Add repr to MultiIndexDFObject

### DIFF
--- a/spectroscopy/code_src/data_structures_spec.py
+++ b/spectroscopy/code_src/data_structures_spec.py
@@ -40,6 +40,12 @@ class MultiIndexDFObject:
         if data is not None:
             self.append(data)
 
+    def _repr_html_(self):
+        return self.data._repr_html_()
+
+    def __repr__(self):
+        return self.data.__repr__()
+
     def append(self, x):
         """
         Add a new spectra data to the dataframe.


### PR DESCRIPTION
Closes #647 

Simple PR to let users type `df_spec` to display the pandas dataframe, as if they had typed `df_spec.data`.