### PR TITLE
Remove Green sample from scale_up

### DIFF
--- a/light_curves/scale_up.md
+++ b/light_curves/scale_up.md
@@ -491,7 +491,6 @@ Define an extended set of parameters and save it as a yaml file:
 yaml_run_id = "demo-kwargs-yaml"
 
 get_samples = {
-    "green": {},
     "ruan": {},
     "papers_list": {
         "paper_kwargs": [


### PR DESCRIPTION
Closes #541 

The scale_up notebook occasionally hits a `ConnectionError` when trying to get a sample from Vizier (#541). It looks like it's always the Green sample and not any others. There's no particular reason to use the Green sample in this notebook, so I propose we just take it out.