### PR TITLE
Retry Keck IRSA queries with async TAP

### DIFF
--- a/spectroscopy/code_src/keck_functions.py
+++ b/spectroscopy/code_src/keck_functions.py
@@ -4,6 +4,7 @@ import pandas as pd
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
 from astroquery.ipac.irsa import Irsa
+from requests.exceptions import ConnectionError, RequestException
 
 from data_structures_spec import MultiIndexDFObject
 
@@ -27,12 +28,33 @@ def KeckDEIMOS_get_spec(sample_table, search_radius_arcsec):
 
     # Initialize multi-index object:
     df_spec = MultiIndexDFObject()
+    max_retries = 2
 
     for stab in sample_table:
 
         search_coords = stab["coord"]
-        tab = Irsa.query_region(coordinates=search_coords, catalog="cosmos_deimos",
-                                spatial="Cone", radius=search_radius_arcsec * u.arcsec)
+        tab = None
+        for attempt in range(max_retries + 1):
+            try:
+                tab = Irsa.query_region(
+                    coordinates=search_coords,
+                    catalog="cosmos_deimos",
+                    spatial="Cone",
+                    radius=search_radius_arcsec * u.arcsec,
+                    async_job=True,
+                )
+                break
+            except (ConnectionError, RequestException) as exc:
+                if attempt == max_retries:
+                    raise RuntimeError(
+                        f"IRSA query failed for source {stab['label']} after "
+                        f"{max_retries + 1} attempts"
+                    ) from exc
+                print(
+                    f"IRSA query attempt {attempt + 1} failed for source "
+                    f"{stab['label']}; retrying."
+                )
+
         print("Number of entries found: {}".format(len(tab)))
 
         if len(tab) == 0:

--- a/spectroscopy/code_src/keck_functions.py
+++ b/spectroscopy/code_src/keck_functions.py
@@ -34,7 +34,7 @@ def KeckDEIMOS_get_spec(sample_table, search_radius_arcsec):
 
         search_coords = stab["coord"]
         tab = None
-        for attempt in range(max_retries + 1):
+        for attempt in range(max_retries):
             try:
                 tab = Irsa.query_region(
                     coordinates=search_coords,
@@ -45,10 +45,10 @@ def KeckDEIMOS_get_spec(sample_table, search_radius_arcsec):
                 )
                 break
             except (ConnectionError, RequestException) as exc:
-                if attempt == max_retries:
+                if attempt == max_retries - 1:
                     raise RuntimeError(
                         f"IRSA query failed for source {stab['label']} after "
-                        f"{max_retries + 1} attempts"
+                        f"{max_retries} attempts"
                     ) from exc
                 print(
                     f"IRSA query attempt {attempt + 1} failed for source "


### PR DESCRIPTION
## Summary
  Switch the spectroscopy tutorial's Keck DEIMOS IRSA query path to use async TAP queries and retry transient request failures twice before raising.

 ## Why
  CI has been intermittently failing when the IRSA TAP service closes a synchronous query connection without responding. Using the async query path is the more
  appropriate fix for that failure mode than only increasing a timeout.

  Closes #581
