### PR TITLE
Restrict Simbad to Taurus Molecular Cloud

### DIFF
--- a/deployed_notebooks_manifest.in
+++ b/deployed_notebooks_manifest.in
@@ -81,3 +81,7 @@ spectroscopy/data/README.md
 spectroscopy/output/README.md
 spectroscopy/requirements_spectra_collector.txt
 spectroscopy/spectra_collector.md
+spectral_cubes/emission_search_cubes.md
+spectral_cubes/requirements_emission_search_cubes.txt
+spectral_cubes/code_src/parse_polygon.py
+spectral_cubes/code_src/find_extended_emission.py

--- a/spectral_cubes/emission_search_cubes.md
+++ b/spectral_cubes/emission_search_cubes.md
@@ -883,8 +883,9 @@ else:
 
 # Execute
 with Pool(num_workers) as pool:
-    results = pool.map(line_search,
-                       [obs for _, obs in copy_yso_jwst_obstable_iterable])
+    results = list(pool.imap_unordered(line_search,
+        (obs for _, obs in copy_yso_jwst_obstable_iterable),
+        chunksize=15))
 ```
 
 ```{code-cell} ipython3

--- a/spectral_cubes/emission_search_cubes.md
+++ b/spectral_cubes/emission_search_cubes.md
@@ -875,11 +875,7 @@ We will make one minor modification to the parallelization approach that we used
 # Use pandas to make the iterable
 copy_yso_jwst_obstable_iterable = copy_yso_jwst_obstable.to_pandas().iterrows()
 
-# Increase the number of workers to compensate for I/O bound tasks
-if num_cores<=4:
-    num_workers = round(num_cores*2)
-else:
-    num_workers = round(num_cores*1.4)
+num_workers = num_cores
 
 # Execute
 with Pool(num_workers) as pool:

--- a/spectral_cubes/emission_search_cubes.md
+++ b/spectral_cubes/emission_search_cubes.md
@@ -114,7 +114,7 @@ At this time, MAST doesn't support reliable object classification search. So let
 In the cell below, we search for all SIMBAD-catalogued objects labeled as YSOs (`otype='Y*O'`) or as any of the descendant sub-concepts of YSOs, like T Tauri stars (`otype='Y*O..'` to retrieve both explicitly labeled YSOs and their subtypes). This cell will take a minute or two.
 
 ```{code-cell} ipython3
-yso_table = Simbad.query_tap("SELECT * FROM basic WHERE otype='Y*O..'", maxrec=1000000)
+yso_table = Simbad.query_hierarchy(name="Taurus Molecular Cloud", hierarchy="children", criteria="otype='Y*O..'")
 ```
 
 ```{code-cell} ipython3
@@ -959,8 +959,8 @@ Let's take a quick look at a random YSO from this list. At the time of writing, 
 
 ```{code-cell} ipython3
 # For demonstration purposes, so that the rest of this section knows what data to expect,
-# get yso_index corresponding to target_name = 'PER-EMB-33'.
-temp_yso_index = max(lines_yso_jwst_obstable['yso_index'][lines_yso_jwst_obstable['target_name']=='PER-EMB-33'])
+# get yso_index corresponding to target_name = 'TAU042021'.
+temp_yso_index = max(lines_yso_jwst_obstable['yso_index'][lines_yso_jwst_obstable['target_name']=='TAU042021'])
 
 # Show the first few observations corresponding to that yso_index
 lines_yso_jwst_obstable[lines_yso_jwst_obstable['yso_index']==temp_yso_index][0:3]
@@ -969,12 +969,12 @@ lines_yso_jwst_obstable[lines_yso_jwst_obstable['yso_index']==temp_yso_index][0:
 We're already familiar with the 5.34 micron line, so let's take a look at that one of the cubes above that contains it:
 
 ```{code-cell} ipython3
-# Retrieve all observations for this YSO with MIRI CH1-SHORT and proposal ID 1236
+# Retrieve all observations for this YSO with MIRI CH1-SHORT and proposal ID 1751
 temp_observations = lines_yso_jwst_obstable[
     (lines_yso_jwst_obstable['yso_index']==temp_yso_index) &
     (lines_yso_jwst_obstable['instrument_name']=='MIRI/IFU') &
     (lines_yso_jwst_obstable['filters']=='CH1-SHORT') &
-    (lines_yso_jwst_obstable['proposal_id']=='1236')
+    (lines_yso_jwst_obstable['proposal_id']=='1751')
 ]
 
 # Get the first valid cloud URI found

--- a/toc.yml
+++ b/toc.yml
@@ -13,6 +13,7 @@ project:
       file: spectroscopy/spectroscopy.md
       children:
         - file: spectroscopy/spectra_collector.md
+        - file: spectral_cubes/emission_search_cubes.md
     - title: Forced Photometry
       file: forced_photometry/forced-photometry.md
       children:


### PR DESCRIPTION
Trying to reduce the runtime of the spectral cubes notebook for #654.

- Restrict the initial Simbad query to the Taurus Molecular Cloud region.
- Demo object PER-EMB-33 isn't in the Taurus Molecular Cloud, so switch that to TAU042021.

I ran this several times on the fornax medium instance with good results. It reduced the runtime of most of the long-running cells:
- First Simbad query 1m -> 1s
- First `pool.map()` call 4m -> 20s
- Last `Observations.get_cloud_uris()` call 2m -> 20s-50s
- Second `pool.map()` call 11m -> 1m30s

Biggest remaining potential issue that I see is the `Observations.query_criteria()` call. Changing the Simbad query doesn't affect this cell, and I've seen it take up to 4m on fornax.