### PR TITLE
Restrict MAST to obs time range

### DIFF
--- a/deployed_notebooks_manifest.in
+++ b/deployed_notebooks_manifest.in
@@ -81,3 +81,7 @@ spectroscopy/data/README.md
 spectroscopy/output/README.md
 spectroscopy/requirements_spectra_collector.txt
 spectroscopy/spectra_collector.md
+spectral_cubes/emission_search_cubes.md
+spectral_cubes/requirements_emission_search_cubes.txt
+spectral_cubes/code_src/parse_polygon.py
+spectral_cubes/code_src/find_extended_emission.py

--- a/spectral_cubes/emission_search_cubes.md
+++ b/spectral_cubes/emission_search_cubes.md
@@ -114,7 +114,7 @@ At this time, MAST doesn't support reliable object classification search. So let
 In the cell below, we search for all SIMBAD-catalogued objects labeled as YSOs (`otype='Y*O'`) or as any of the descendant sub-concepts of YSOs, like T Tauri stars (`otype='Y*O..'` to retrieve both explicitly labeled YSOs and their subtypes). This cell will take a minute or two.
 
 ```{code-cell} ipython3
-yso_table = Simbad.query_tap("SELECT * FROM basic WHERE otype='Y*O..'", maxrec=1000000)
+yso_table = Simbad.query_hierarchy(name="Taurus Molecular Cloud", hierarchy="children", criteria="otype='Y*O..'")
 ```
 
 ```{code-cell} ipython3

--- a/spectral_cubes/emission_search_cubes.md
+++ b/spectral_cubes/emission_search_cubes.md
@@ -62,7 +62,7 @@ import matplotlib.pyplot as plt
 from matplotlib.gridspec import GridSpec
 from matplotlib.colors import PowerNorm
 
-# Wrangle data 
+# Wrangle data
 from astropy.table import Table, Column, Row
 from astropy.io import fits
 import pandas as pd

--- a/spectral_cubes/emission_search_cubes.md
+++ b/spectral_cubes/emission_search_cubes.md
@@ -148,6 +148,7 @@ This cell will typically take anywhere from a few seconds to a minute or so, dep
 jwst_obstable = Observations.query_criteria(dataproduct_type='cube',
                                             obs_collection='JWST',
                                             dataRights='PUBLIC',  # Limit to public data
+                                            t_min=[59824.6, 60007.4],  # Include TMC1A and PER-EMB-33
                                             calib_level = [0, 1, 2, 3, 4])  # Exclude planned observations
 ```
 

--- a/toc.yml
+++ b/toc.yml
@@ -13,6 +13,7 @@ project:
       file: spectroscopy/spectroscopy.md
       children:
         - file: spectroscopy/spectra_collector.md
+        - file: spectral_cubes/emission_search_cubes.md
     - title: Forced Photometry
       file: forced_photometry/forced-photometry.md
       children:


### PR DESCRIPTION
Trying to reduce the runtime of the spectral cubes notebook for #654.

- Restrict the `Observations.query_criteria()` call to `t_min` in range [59824.6, 60007.4], which includes the two demo objects TMC1A and PER-EMB-33.

I ran this several times on the fornax medium instance with reasonably good results. It reduced the runtime of most of the long-running cells:
- `Observations.query_criteria()` call 30s-4m -> 40s-1m30s
- First `pool.map()` call 4m -> 30s
- Last `Observations.get_cloud_uris()` call 2m -> 20s
- Second `pool.map()` call 11m -> 2m30s

#668 is slightly better overall, but the gain here for the `Observations.query_criteria()` might be more important for the CI since the runtime for that cell can vary widely.