### PR TITLE
Make lsdb calls more efficient and upgrade lsdb

### DIFF
--- a/crossmatch/requirements_ztf_ps1_crossmatch.txt
+++ b/crossmatch/requirements_ztf_ps1_crossmatch.txt
@@ -1,11 +1,7 @@
 astropy
 pandas
 matplotlib
-# >=0.6.5 for ConeSearch import. https://github.com/nasa-fornax/fornax-demo-notebooks/issues/523
-# Upper limit <0.8 is for instant workaround of coming incompatibility https://github.com/nasa-fornax/fornax-demo-notebooks/issues/587
-lsdb>=0.6.5,<0.8
-# Indirect dependency of lsdb via hats. Remove once our minimum required version of lsdb/hats is 0.8.1
-cdshealpix<0.8
+lsdb>=0.8.1
 dask
 # Required by lsdb to read files from AWS S3, revise when lsdb[s3fs] is supported by required minimum version.
 s3fs

--- a/crossmatch/ztf_ps1_crossmatch.md
+++ b/crossmatch/ztf_ps1_crossmatch.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.17.2
+    jupytext_version: 1.19.1
 kernelspec:
   display_name: py-ztf_ps1_crossmatch
   language: python
@@ -170,7 +170,8 @@ ps1 = lsdb.open_catalog(ps1_path, columns=["objName","objID","raMean","decMean"]
 
 ```{code-cell} ipython3
 # Setting up the cross-match actually takes very little time
-ztf_x_ps1 = ztf_piece.crossmatch(ps1, radius_arcsec=1, n_neighbors=1, suffixes=("_ztf", "_ps1"))
+ztf_x_ps1 = ztf_piece.crossmatch(ps1, radius_arcsec=1, n_neighbors=1,
+                                 suffixes=("_ztf", "_ps1"), suffix_method='all_columns')
 ztf_x_ps1
 ```
 

--- a/light_curves/code_src/lsdb_utils.py
+++ b/light_curves/code_src/lsdb_utils.py
@@ -1,0 +1,31 @@
+import lsdb
+import pandas as pd
+
+
+def sample_table_to_lsdb(sample_table):
+    """Convert a sample astropy Table to an LSDB catalog.
+
+    Parameters
+    ----------
+    sample_table : astropy.table.Table
+        Table with columns: coord (SkyCoord), objectid (int), label (str).
+
+    Returns
+    -------
+    lsdb.Catalog
+        Spatially partitioned catalog ready for crossmatch or join.
+    """
+    # SkyCoord cannot be stored directly in a DataFrame; extract ra/dec explicitly
+    sample_df = pd.DataFrame({
+        'objectid': sample_table['objectid'],
+        'ra_deg': sample_table['coord'].ra.deg,
+        'dec_deg': sample_table['coord'].dec.deg,
+        'label': sample_table['label'],
+    })
+    return lsdb.from_dataframe(
+        sample_df,
+        ra_column="ra_deg",
+        dec_column="dec_deg",
+        margin_threshold=10,
+        drop_empty_siblings=True,
+    )

--- a/light_curves/code_src/panstarrs_functions.py
+++ b/light_curves/code_src/panstarrs_functions.py
@@ -4,6 +4,7 @@ import pandas as pd
 from dask.distributed import Client
 
 from data_structures import MultiIndexDFObject
+from lsdb_utils import sample_table_to_lsdb
 
 # panstarrs light curves from hats catalog in S3 using lsdb
 
@@ -56,22 +57,8 @@ def panstarrs_get_lightcurves(sample_table, *, radius=1):
                  "nStackDetections",  # some other data to use
                  ]
     )
-    # convert astropy table to pandas dataframe
-    # special care for the SkyCoords in the table
-    sample_df = pd.DataFrame({'objectid': sample_table['objectid'],
-                              'ra_deg': sample_table['coord'].ra.deg,
-                              'dec_deg': sample_table['coord'].dec.deg,
-                              'label': sample_table['label']})
-
-    # convert dataframe to hipscat
-    sample_lsdb = lsdb.from_dataframe(
-        sample_df,
-        ra_column="ra_deg",
-        dec_column="dec_deg",
-        margin_threshold=10,
-        # Optimize partition size
-        drop_empty_siblings=True
-    )
+    # convert astropy table to lsdb catalog
+    sample_lsdb = sample_table_to_lsdb(sample_table)
 
     # plan to cross match panstarrs object with my sample
     # only keep the best match

--- a/light_curves/code_src/panstarrs_functions.py
+++ b/light_curves/code_src/panstarrs_functions.py
@@ -56,17 +56,6 @@ def panstarrs_get_lightcurves(sample_table, *, radius=1):
                  "nStackDetections",  # some other data to use
                  ]
     )
-    # read in the panstarrs light curves to lsdb
-    # panstarrs recommendation is not to index into this table with ra and dec
-    # but to use object ids from the above object table
-    panstarrs_detect = lsdb.open_catalog(
-        's3://stpubdata/panstarrs/ps1/public/hats/detection',
-        columns=["objID",  # PS1 object ID
-                 "detectID",  # PS1 detection ID
-                 # light-curve stuff
-                 "obsTime", "filterID", "psfFlux", "psfFluxErr",
-                 ]
-    )
     # convert astropy table to pandas dataframe
     # special care for the SkyCoords in the table
     sample_df = pd.DataFrame({'objectid': sample_table['objectid'],
@@ -92,6 +81,20 @@ def panstarrs_get_lightcurves(sample_table, *, radius=1):
         n_neighbors=1,
         suffixes=("", ""),
         suffix_method="all_columns",
+    )
+
+    # read in the panstarrs light curves to lsdb, pre-filtered to the matched sky pixels
+    # to keep the join task graph small (~83K → ~84 partitions) and faster (~2x).
+    # panstarrs recommendation is not to index into this table with ra and dec
+    # but to use object ids from the above object table.
+    panstarrs_detect = lsdb.open_catalog(
+        's3://stpubdata/panstarrs/ps1/public/hats/detection',
+        search_filter=lsdb.PixelSearch(matched_objects.get_healpix_pixels()),
+        columns=["objID",  # PS1 object ID
+                 "detectID",  # PS1 detection ID
+                 # light-curve stuff
+                 "obsTime", "filterID", "psfFlux", "psfFluxErr",
+                 ]
     )
 
     # plan to join that cross match with detections to get light-curves

--- a/light_curves/code_src/panstarrs_functions.py
+++ b/light_curves/code_src/panstarrs_functions.py
@@ -67,7 +67,8 @@ def panstarrs_get_lightcurves(sample_table, *, radius=1):
         radius_arcsec=radius,
         n_neighbors=1,
         suffixes=("", ""),
-        suffix_method="all_columns",
+        suffix_method="overlapping_columns",
+        log_changes=False,
     )
 
     # read in the panstarrs light curves to lsdb, pre-filtered to the matched sky pixels
@@ -91,7 +92,8 @@ def panstarrs_get_lightcurves(sample_table, *, radius=1):
         right_on="objID",
         output_catalog_name="yang_ps_lc",
         suffixes=["", ""],
-        suffix_method="all_columns",
+        suffix_method="overlapping_columns",
+        log_changes=False,
     )
 
     # Create default local cluster

--- a/light_curves/code_src/ztf_functions.py
+++ b/light_curves/code_src/ztf_functions.py
@@ -52,16 +52,9 @@ def ztf_get_lightcurves(sample_table, *, radius=1.0):
     - Fluxes are converted from AB magnitudes using Astropy, then converted to mJy.
     """
     
-    # 1) Start Dask client & read full ZTF light-curve catalog
+    # 1) Start Dask client
     # Use multiple workers with a single thread per worker for better performance on Fornax
     client = Client(threads_per_worker=1, memory_limit=None)
-    ztf_lc = lsdb.read_hats(
-        's3://ipac-irsa-ztf/contributed/dr23/lc/hats/',
-        columns=[
-            "objectid", "objra", "objdec", "filterid",
-            "lightcurve.hmjd", "lightcurve.mag", "lightcurve.magerr", "lightcurve.catflags"
-        ]
-    )
 
     # 2) Convert Astropy table → pandas → LSDB catalog
     sample_df = pd.DataFrame({
@@ -84,8 +77,15 @@ def ztf_get_lightcurves(sample_table, *, radius=1.0):
     per_band_dfs = []
 
     for fid, band_name in band_map.items():
-        # 3a) filter to one band and select relevant sky tiles
-        ztf_band = ztf_lc.query(f"filterid == {fid}")
+        # 3a) open ZTF light-curve catalog filtered to each band 
+        ztf_band = lsdb.open_catalog(
+            's3://ipac-irsa-ztf/contributed/dr23/lc/hats/',
+            filters=[("filterid", "==", fid)],
+            columns=[
+                "objectid", "objra", "objdec", "filterid",
+                "lightcurve.hmjd", "lightcurve.mag", "lightcurve.magerr", "lightcurve.catflags"
+            ]
+        )
 
         # 3b) crossmatch: sample (left) → filtered band (right)
         matched = sample_lsdb.crossmatch(

--- a/light_curves/code_src/ztf_functions.py
+++ b/light_curves/code_src/ztf_functions.py
@@ -4,6 +4,7 @@ from astropy import units as u
 from dask.distributed import Client
 
 from data_structures import MultiIndexDFObject
+from lsdb_utils import sample_table_to_lsdb
 
 
 def ztf_get_lightcurves(sample_table, *, radius=1.0):
@@ -56,21 +57,8 @@ def ztf_get_lightcurves(sample_table, *, radius=1.0):
     # Use multiple workers with a single thread per worker for better performance on Fornax
     client = Client(threads_per_worker=1, memory_limit=None)
 
-    # 2) Convert Astropy table → pandas → LSDB catalog
-    sample_df = pd.DataFrame({
-        'objectid': sample_table['objectid'],
-        'ra_deg': sample_table['coord'].ra.deg,
-        'dec_deg': sample_table['coord'].dec.deg,
-        'label': sample_table['label'],
-    })
-    sample_lsdb = lsdb.from_dataframe(
-        sample_df,
-        ra_column="ra_deg",
-        dec_column="dec_deg",
-        margin_threshold=10,
-        drop_empty_siblings=True
-    )
-    del sample_df
+    # 2) Convert Astropy table → LSDB catalog
+    sample_lsdb = sample_table_to_lsdb(sample_table)
 
     # 3) Cross-match per band
     band_map = {1: "ztf_g", 2: "ztf_r", 3: "ztf_i"}

--- a/light_curves/code_src/ztf_functions.py
+++ b/light_curves/code_src/ztf_functions.py
@@ -82,13 +82,14 @@ def ztf_get_lightcurves(sample_table, *, radius=1.0):
             n_neighbors=1,
             require_right_margin=True,
             suffixes=("_sample", ""),
-            suffix_method="all_columns",
+            suffix_method="overlapping_columns",
+            log_changes=False,
         )
         df = matched.compute()
 
         # 3c) explode to one row per data point, add band name, and drop points with bad flags
         df["lightcurve.objectid"] = df["objectid_sample"]
-        df["lightcurve.label"] = df["label_sample"]
+        df["lightcurve.label"] = df["label"]
         df["lightcurve.band"] = band_name
         df = df["lightcurve"].nest.to_flat()
         df = df.query("catflags < 32768")

--- a/light_curves/light_curve_collector.md
+++ b/light_curves/light_curve_collector.md
@@ -268,8 +268,6 @@ print('WISE search took:', time.time() - WISEstarttime, 's')
 
 The function to retrieve lightcurves from Pan-STARRS uses [LSDB](https://docs.lsdb.io/) to access versions of the object and light curve catalogs that are stored in the cloud.  This function is efficient at large scale (sample sizes > ~1000).
 
-When running this step, you may see a Dask warning about a “large task graph.” This can be safely ignored.
-
 ```{code-cell} ipython3
 panstarrsstarttime = time.time()
 
@@ -281,8 +279,6 @@ df_lc_panstarrs = panstarrs_get_lightcurves(sample_table, radius=panstarrs_searc
 df_lc.append(df_lc_panstarrs)
 
 print('Panstarrs search took:', time.time() - panstarrsstarttime, 's')
-
-# Warnings from the panstarrs query are expected and can be ignored. 
 ```
 
 ### 2.4 MAST: TESS, Kepler and K2

--- a/light_curves/requirements_light_curve_collector.txt
+++ b/light_curves/requirements_light_curve_collector.txt
@@ -14,11 +14,7 @@ astroquery>=0.4.8.dev0
 acstools
 lightkurve
 alerce
-# >=0.6.2 for improved s3 read speed.
-# Upper limit <0.8 is for instant workaround of coming incompatibility https://github.com/nasa-fornax/fornax-demo-notebooks/issues/587
-lsdb>=0.6.2,<0.8
-# Indirect dependency of lsdb via hats. Remove once our minimum required version of lsdb/hats is 0.8.1
-cdshealpix<0.8
+lsdb>=0.8.1
 # Required by lsdb to read files from AWS S3, revise when lsdb[s3fs] is supported by required minimum version.
 s3fs
 # Required by lsdb, a few versions are known to cause issues

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,15 @@ deps =
     # versions for specific testing scenarios
     buildhtml: -rsite-requirements.txt
 
+    # Ugly workaround for the custom install_command to ensure the the arguments are properly passed into pip
+    buildhtml: pip
+
+install_command =
+    # lsdb has tighter minimum dependencies, requiring the much latest 0.8.1 causes issues with the unified install for html building, we override the minimum requireed version here.
+    buildhtml: bash -c "sed -i -e 's|lsdb>=0.8.1|lsdb>=0.6.5\ncdshealpix<0.8|g' crossmatch/requirements_ztf_ps1_crossmatch.txt light_curves/requirements_light_curve_collector.txt && python -I -m pip install $@"
+
+    !buildhtml: python -I -m pip install {opts} {packages}
+
 
 allowlist_externals =
     bash


### PR DESCRIPTION
Fixes #646, also fixes #587 

Regarding the lsdb upgrade, the warning about explicitly setting `suffix_method` is still there (even in v0.9). It is just cautioning because default will change from `all_columns` to `overlapping_columns`. #608 already explicitly defined `suffix_method="all_columns"` so we were safe to upgrade lsdb even then. I have set the same in `ztf_ps1_crossmatch.md` but I changed `light_curve_collector` functions to  use `overlapping_columns` and made relevant dataframe column name updates because I got the impression that's what #587 was suggesting.

## Benchmarking
### 6 May — lsdb calls updated                                                                                                         
                                      
  | Change | Before (s) | After (s) | Improvement |                                                                                     
  |---|---|---|---|
  | ZTF: `filterid` filter moved into `open_catalog()` | 173.96 | 136.11 | −21.8% |                                                      
  | PanSTARRS: open detection catalog with `PixelSearch` filter | 85 | 45 | −47.1% |
                                                                                                                                         
### 12 May — lsdb calls updated + lsdb upgraded to ≥0.8.1       
                                                                                                                                                                                                                
  | Change | Before (s) | After (s) | Improvement |                                                                                     
  |---|---|---|---|
  | ZTF: `filterid` filter moved into `open_catalog()` | 198 | 147 | −25.7% |                                                            
  | PanSTARRS: open detection catalog with `PixelSearch` filter  | 100 | 61 | −39.0% |

Note: Timings in "Before" column (executing the tutorial in fornax production) differ between the two tables (e.g. 173s vs 198s before) likely just due to environment/dask cluster variability on the day.
