### PR TITLE
MAINT: bumping python version for HTML rendering and deploy job

### DIFF
--- a/.github/workflows/ci_publish.yml
+++ b/.github/workflows/ci_publish.yml
@@ -30,13 +30,13 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Install dependencies
         run: python -m pip install --upgrade tox
 
       - name: Execute notebooks while building HTMLs
-        run: tox -e py312-buildhtml
+        run: tox -e py313-buildhtml
 
       - name: Publish HTML when on main
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/spectroscopy/spectra_collector.md
+++ b/spectroscopy/spectra_collector.md
@@ -297,7 +297,6 @@ This includes DESI spectra. Here, we use the `SPARCL` query. Note that this can 
 for SDSS searches, however, according to the SPARCL webpage, only up to DR16 is included.
 Therefore, we will not include SDSS DR16 here (this is treated in the SDSS search above).
 
-The DESI search is currently commented out because `SPARCL` is not compatible with numpy > 2 which we require for the other modules to run.
 
 ```{code-cell} ipython3
 ## Get DESI and BOSS spectra with SPARCL


### PR DESCRIPTION
This should take care of some pandas version conflicts between lsdb/nested-pandas and sparclclient. 

[edit:] - It seems that #677 maybe a fornax issue as from a fresh env on circleCI, the build is passing and for GHA it might have been enough that this PR is bumping  the python version (we already use 3.13 on circleCI).

~However, as #677 reported we run into some other issues with sparcl, so this PR will also add a temporarily comment-out for the DESI sections of the affected notebook.~

closes #677

