### PR TITLE
MAINT: don't pick up dev versions

### DIFF
--- a/light_curves/requirements_light_curve_collector.txt
+++ b/light_curves/requirements_light_curve_collector.txt
@@ -10,7 +10,7 @@ matplotlib
 hpgeom
 astropy
 pyvo
-astroquery>=0.4.8.dev0
+astroquery>=0.4.8
 acstools
 lightkurve
 alerce


### PR DESCRIPTION
Apparently the resolver picked up the dev version even if a tagged release satisfies the requirement.

I think this should fix, potentially, #682. Whether it's still an issue with astroquery-dev is a separate question and should be double checked before the new release