### PR TITLE
Use Gaia hats in light_curve_collector

### DIFF
--- a/light_curves/code_src/gaia_functions.py
+++ b/light_curves/code_src/gaia_functions.py
@@ -1,8 +1,11 @@
 import time
 
+import lsdb
 import numpy as np
 import pandas as pd
+from astropy.table import Table
 from astroquery.gaia import Gaia
+from dask.distributed import Client
 
 from data_structures import MultiIndexDFObject
 
@@ -49,10 +52,11 @@ def gaia_get_lightcurves(sample_table, *, search_radius=1 / 3600, verbose=0):
 
     '''
     # This code is broken into two steps.  The first step, `gaia_retrieve_catalog` retrieves the
-    # Gaia source ids for the positions of our sample. These come from the "Gaia DR3 source lite catalog".
+    # Gaia source ids for the positions of our sample. These come from the Gaia DR3 "gaia_source"
+    # catalog, accessed as a HATS catalog on AWS S3 and cross-matched with LSDB.
     # However, that catalog only has a single photometry point per object.  To get the light curve
     # information, we use the function `gaia_retrieve_epoch_photometry` to use the source ids to
-    # access the "EPOCH_PHOTOMETRY" catalog.
+    # access the "EPOCH_PHOTOMETRY" catalog via the Gaia DataLink service.
 
     # Retrieve Gaia table with Source IDs ==============
     gaia_table = gaia_retrieve_catalog(sample_table,
@@ -81,7 +85,8 @@ def gaia_get_lightcurves(sample_table, *, search_radius=1 / 3600, verbose=0):
 
 def gaia_retrieve_catalog(sample_table, search_radius, verbose):
     '''
-    Retrieves the photometry table for a list of sources.
+    Retrieves the Gaia DR3 source_ids for a list of sources by cross-matching against the
+    Gaia DR3 "gaia_source" HATS catalog hosted on AWS S3, using LSDB.
 
     Parameter
     ----------
@@ -102,15 +107,13 @@ def gaia_retrieve_catalog(sample_table, search_radius, verbose):
     Returns
     --------
     gaia_table : astropy.table.Table
-        Table containing Gaia DR3 source matches for the input coordinates.
-        The table includes the following columns:
+        Table containing Gaia DR3 source matches for the input coordinates, restricted to
+        sources that have epoch photometry available. The table includes the following columns:
 
             ra : float
                 Right Ascension of the matched Gaia source (degrees).
             dec : float
                 Declination of the matched Gaia source (degrees).
-            random_index : int
-                Gaia random index used for efficient data server partitioning.
             source_id : int
                 Unique Gaia DR3 source identifier.
             objectid : int
@@ -120,32 +123,56 @@ def gaia_retrieve_catalog(sample_table, search_radius, verbose):
     '''
     t1 = time.time()
 
-    # first make an astropy table from our master list of coordinates
-    # as input to the pyvo TAP query
-    upload_table = sample_table['objectid', 'label']
-    upload_table['ra'] = sample_table['coord'].ra.deg
-    upload_table['dec'] = sample_table['coord'].dec.deg
+    # Open the Gaia DR3 "gaia_source" HATS catalog hosted on AWS S3 (via the STScI registry).
+    # This catalog has a single row per source; we only need enough columns to cross-match and
+    # to grab the source_id used to request epoch photometry from the DataLink service below.
+    # has_epoch_photometry lets us skip sources with no light curve before we ever hit DataLink.
+    gaia_object = lsdb.open_catalog(
+        's3://stpubdata/gaia/gaia_dr3/public/hats/',
+        columns=["source_id", "ra", "dec", "has_epoch_photometry"],
+    )
 
-    # this query is too slow without gaia.random_index.
-    # Gaia helpdesk is aware of this bug somewhere on their end
-    querystr = f"""
-        SELECT gaia.ra, gaia.dec, gaia.random_index, gaia.source_id, mt.ra, mt.dec, mt.objectid, mt.label
-        FROM tap_upload.table_test AS mt
-        JOIN gaiadr3.gaia_source_lite AS gaia
-        ON 1=CONTAINS(POINT('ICRS',mt.ra,mt.dec),CIRCLE('ICRS',gaia.ra,gaia.dec,{search_radius}))
-        """
-    # use an asynchronous query of the Gaia database
-    # cross match with our uploaded table
-    j = Gaia.launch_job_async(query=querystr, upload_resource=upload_table,
-                              upload_table_name="table_test")
+    # convert our sample's coordinates into an LSDB catalog for cross-matching
+    sample_df = pd.DataFrame({
+        'objectid': sample_table['objectid'],
+        'ra_deg': sample_table['coord'].ra.deg,
+        'dec_deg': sample_table['coord'].dec.deg,
+        'label': sample_table['label'],
+    })
+    sample_lsdb = lsdb.from_dataframe(
+        sample_df,
+        ra_column="ra_deg",
+        dec_column="dec_deg",
+        margin_threshold=10,
+        drop_empty_siblings=True,
+    )
 
-    results = j.get_results()
+    # cross-match our sample (left) against Gaia (right), keeping only the nearest source.
+    # search_radius is in degrees (for backwards compatibility); LSDB wants arcseconds.
+    matched = sample_lsdb.crossmatch(
+        gaia_object,
+        radius_arcsec=search_radius * 3600,
+        n_neighbors=1,
+        suffixes=("", ""),
+        suffix_method="all_columns",
+    )
+
+    # the cross-match is lazy; run it on a local Dask cluster.
+    # Use multiple workers with a single thread per worker for better performance on Fornax
+    with Client(threads_per_worker=1, memory_limit=None):
+        matched_df = matched.compute()
+
+    # only keep sources that actually have epoch photometry to retrieve from DataLink
+    matched_df = matched_df[matched_df["has_epoch_photometry"].astype(bool)]
 
     if verbose:
         print(f"\nSearch completed in {time.time() - t1:.2f} seconds \n"
-              f"Number of objects matched: {len(results)} out of {len(sample_table)}.")
+              f"Number of objects matched: {len(matched_df)} out of {len(sample_table)}.")
 
-    return results
+    # return an astropy table with the columns gaia_retrieve_epoch_photometry expects
+    return Table.from_pandas(
+        matched_df[["ra", "dec", "source_id", "objectid", "label"]].reset_index(drop=True)
+    )
 
 
 def gaia_chunks(lst, n):

--- a/light_curves/code_src/gaia_functions.py
+++ b/light_curves/code_src/gaia_functions.py
@@ -3,11 +3,16 @@ import time
 import lsdb
 import numpy as np
 import pandas as pd
-from astropy.table import Table
-from astroquery.gaia import Gaia
 from dask.distributed import Client
 
 from data_structures import MultiIndexDFObject
+
+# Gaia DR3 epoch photometry, hosted as a HATS catalog by LINCC.
+# This "object" catalog holds exactly the DR3 sources that have epoch photometry (one row per
+# source), with the light curves stored in a nested `epoch_photometry` column. Because it is
+# crossmatchable by position and already restricted to sources with light curves, a single
+# LSDB cross-match returns both the source match and its epoch photometry.
+GAIA_EPOCH_PHOT_HATS = "https://data.lsdb.io/hats/gaia_dr3_epoch_phot/"
 
 
 def gaia_get_lightcurves(sample_table, *, search_radius=1 / 3600, verbose=0):
@@ -24,7 +29,7 @@ def gaia_get_lightcurves(sample_table, *, search_radius=1 / 3600, verbose=0):
             objectid : int
                 Unique identifier for each source in the sample.
             label : str
-                Literature label for tracking source provenance.   
+                Literature label for tracking source provenance.
     search_radius: float(degrees)
         Cone-search radius in degrees for matching Gaia DR3 sources.
         Default is 1/3600 (1 arcsec).
@@ -36,7 +41,7 @@ def gaia_get_lightcurves(sample_table, *, search_radius=1 / 3600, verbose=0):
     df_lc : MultiIndexDFObject
         Indexed by [objectid, label, band, time]. The resulting internal pandas DataFrame
         contains the following columns:
-        
+
             flux : float
                 Gaia G-band transit flux in electrons per second (e-/s).
             err : float
@@ -51,27 +56,14 @@ def gaia_get_lightcurves(sample_table, *, search_radius=1 / 3600, verbose=0):
                 Literature label associated with each source.
 
     '''
-    # This code is broken into two steps.  The first step, `gaia_retrieve_catalog` retrieves the
-    # Gaia source ids for the positions of our sample. These come from the Gaia DR3 "gaia_source"
-    # catalog, accessed as a HATS catalog on AWS S3 and cross-matched with LSDB.
-    # However, that catalog only has a single photometry point per object.  To get the light curve
-    # information, we use the function `gaia_retrieve_epoch_photometry` to use the source ids to
-    # access the "EPOCH_PHOTOMETRY" catalog via the Gaia DataLink service.
-
-    # Retrieve Gaia table with Source IDs ==============
-    gaia_table = gaia_retrieve_catalog(sample_table,
-                                       search_radius=search_radius,
-                                       verbose=verbose
-                                       )
-    # if none of the objects were found, there's nothing to load and the gaia_retrieve_epoch_photometry fnc
-    # will raise an HTTPError. just return an empty dataframe instead of proceeding
-    if len(gaia_table) == 0:
-        return MultiIndexDFObject()
-
-    # Extract Light curves ===============
-    # request the EPOCH_PHOTOMETRY from the Gaia DataLink Service
-
-    gaia_df = gaia_retrieve_epoch_photometry(gaia_table)
+    # We cross-match our sample against the Gaia DR3 epoch-photometry HATS catalog with LSDB
+    # (the same cloud-native approach used for the ZTF and Pan-STARRS light curves). That
+    # catalog already contains only the sources that have epoch photometry, stored in a nested
+    # column, so a single cross-match returns the light curves directly.
+    gaia_df = gaia_retrieve_epoch_photometry(sample_table,
+                                             search_radius=search_radius,
+                                             verbose=verbose
+                                             )
 
     # if the epochal photometry is empty, return an empty dataframe
     if len(gaia_df) == 0:
@@ -83,12 +75,12 @@ def gaia_get_lightcurves(sample_table, *, search_radius=1 / 3600, verbose=0):
     return df_lc
 
 
-def gaia_retrieve_catalog(sample_table, search_radius, verbose):
+def gaia_retrieve_epoch_photometry(sample_table, search_radius, verbose):
     '''
-    Retrieves the Gaia DR3 source_ids for a list of sources by cross-matching against the
-    Gaia DR3 "gaia_source" HATS catalog hosted on AWS S3, using LSDB.
+    Retrieves Gaia DR3 epoch photometry for a list of sources by cross-matching against the
+    Gaia DR3 epoch-photometry HATS catalog hosted by LINCC, using LSDB.
 
-    Parameter
+    Parameters
     ----------
     sample_table : astropy.table.Table
         Table containing the source sample. The following columns must be present:
@@ -106,16 +98,18 @@ def gaia_retrieve_catalog(sample_table, search_radius, verbose):
 
     Returns
     --------
-    gaia_table : astropy.table.Table
-        Table containing Gaia DR3 source matches for the input coordinates, restricted to
-        sources that have epoch photometry available. The table includes the following columns:
+    gaia_df : pandas.DataFrame
+        Flattened Gaia epoch photometry, one row per transit measurement, for the matched
+        sources. The resulting DataFrame contains the following columns:
 
-            ra : float
-                Right Ascension of the matched Gaia source (degrees).
-            dec : float
-                Declination of the matched Gaia source (degrees).
-            source_id : int
-                Unique Gaia DR3 source identifier.
+            g_transit_flux : float
+                Gaia G-band transit flux (electrons per second).
+            g_transit_flux_error : float
+                Flux uncertainty (electrons per second).
+            g_transit_mag : float
+                Gaia G-band magnitude for the transit.
+            g_transit_time : float
+                Time of observation in Gaia mission time (days).
             objectid : int
                 Input sample object identifier.
             label : str
@@ -123,13 +117,11 @@ def gaia_retrieve_catalog(sample_table, search_radius, verbose):
     '''
     t1 = time.time()
 
-    # Open the Gaia DR3 "gaia_source" HATS catalog hosted on AWS S3 (via the STScI registry).
-    # This catalog has a single row per source; we only need enough columns to cross-match and
-    # to grab the source_id used to request epoch photometry from the DataLink service below.
-    # has_epoch_photometry lets us skip sources with no light curve before we ever hit DataLink.
-    gaia_object = lsdb.open_catalog(
-        's3://stpubdata/gaia/gaia_dr3/public/hats/',
-        columns=["source_id", "ra", "dec", "has_epoch_photometry"],
+    # Open the Gaia DR3 epoch-photometry HATS catalog. We only need the light curves (nested in
+    # `epoch_photometry`); ra/dec are used implicitly for the positional cross-match.
+    epoch_catalog = lsdb.open_catalog(
+        GAIA_EPOCH_PHOT_HATS,
+        columns=["ra", "dec", "source_id", "epoch_photometry"],
     )
 
     # convert our sample's coordinates into an LSDB catalog for cross-matching
@@ -150,7 +142,7 @@ def gaia_retrieve_catalog(sample_table, search_radius, verbose):
     # cross-match our sample (left) against Gaia (right), keeping only the nearest source.
     # search_radius is in degrees (for backwards compatibility); LSDB wants arcseconds.
     matched = sample_lsdb.crossmatch(
-        gaia_object,
+        epoch_catalog,
         radius_arcsec=search_radius * 3600,
         n_neighbors=1,
         suffixes=("", ""),
@@ -162,129 +154,27 @@ def gaia_retrieve_catalog(sample_table, search_radius, verbose):
     with Client(threads_per_worker=1, memory_limit=None):
         matched_df = matched.compute()
 
-    # only keep sources that actually have epoch photometry to retrieve from DataLink
-    matched_df = matched_df[matched_df["has_epoch_photometry"].astype(bool)]
-
     if verbose:
         print(f"\nSearch completed in {time.time() - t1:.2f} seconds \n"
               f"Number of objects matched: {len(matched_df)} out of {len(sample_table)}.")
 
-    # return an astropy table with the columns gaia_retrieve_epoch_photometry expects
-    return Table.from_pandas(
-        matched_df[["ra", "dec", "source_id", "objectid", "label"]].reset_index(drop=True)
-    )
-
-
-def gaia_chunks(lst, n):
-    """
-    "Split an input list into multiple chunks of size =< n"
-
-    Parameters
-    ----------
-    lst: list of gaia Ids
-    n: int = maximum size of the desired chunk
-
-    """
-    for i in range(0, len(lst), n):
-        yield lst[i:i + n]
-
-
-def gaia_retrieve_epoch_photometry(gaia_table):
-    """
-    Function to retrieve EPOCH_PHOTOMETRY catalog product for Gaia
-    entries using the DataLink. Note that the IDs need to be DR3 source_id and needs to be a list.
-
-    Code fragments taken from:
-    https://www.cosmos.esa.int/web/gaia-users/archive/datalink-products#datalink_jntb_get_above_lim
-
-    Parameters
-    ----------
-    gaia_table: Astropy Table
-        Table returned by gaia_retrieve_catalog. Must include:
-        source_id : int
-            Gaia DR3 source identifier for the photometry request.
-        objectid : int
-            Used to label the MultiIndex rows later.
-        label : str
-            Text label used for grouping and plotting.
-
-    Returns
-    --------
-    gaia_df : pandas.DataFrame
-        Concatenated Gaia epoch photometry for all matched sources.
-        The resulting DataFrame contains the following columns:
-
-            source_id : int
-                Gaia DR3 source identifier for this transit measurement.
-            g_transit_flux : float
-                Gaia G-band transit flux (electrons per second).
-            g_transit_flux_error : float
-                Flux uncertainty (electrons per second).
-            g_transit_mag : float
-                Gaia G-band magnitude for the transit.
-            g_transit_time : float
-                Time of observation in Gaia mission time (days).
-            objectid : int
-                Input sample object identifier.
-            label : str
-                Literature label associated with each source.
-    """
-
-    # gaia datalink server has a threshold of max 5000 requests,
-    # so we break the input datasets into chunks of size <=5000 sources
-    # and then send each chunk into the datalink server
-    ids = list(gaia_table["source_id"])
-    dl_threshold = 5000  # Datalink server threshold
-    ids_chunks = list(gaia_chunks(ids, dl_threshold))
-    datalink_all = []
-
-    # setup to request the epochal photometry
-    # See astroquery.gaia.Gaia.load_data docs for options for parameter options as they may change
-    retrieval_type = "EPOCH_PHOTOMETRY"
-    data_structure = "RAW"
-    data_release = "Gaia DR3"
-
-    for chunk in ids_chunks:
-        datalink = Gaia.load_data(ids=chunk,
-                                  data_release=data_release,
-                                  retrieval_type=retrieval_type,
-                                  data_structure=data_structure,
-                                  verbose=False,
-                                  valid_data=True,
-                                  overwrite_output_file=True,
-                                  format="votable")
-
-        # datalink contains a single VOTable, but it's wrapped in a list which is itself wrapped in a dict
-        # it's safest to act as if both list and dict may contain an arbitrary number of items
-        # we want to extract the VO table, turn it into a pandas dataframe, and add it to the datalink_all list
-        for list_of_tables in datalink.values():
-            for votable in list_of_tables:
-                # We need to filter out masked cells from the multidim rows, so we can convert them later to a
-                # MultiIndexDFObject avoiding the ``TypeError: unhashable type: 'MaskedConstant'``.
-
-                import numpy.ma
-                arr_cols = ['g_transit_flux', 'g_transit_flux_error',
-                            'g_transit_mag', 'g_transit_time']
-                keep_cols = arr_cols + ['source_id']
-
-                datalink_df = votable.to_table()[keep_cols].to_pandas().explode(arr_cols)
-                mask = np.array(
-                    [val is numpy.ma.masked for val in datalink_df.g_transit_flux.to_numpy()])
-                datalink_df = datalink_df.loc[~mask].astype({col: float for col in arr_cols})
-                datalink_all.append(datalink_df)
-
-    # if there is no epochal photometry return an empty dataframe
-    if len(datalink_all) == 0:
+    if len(matched_df) == 0:
         return pd.DataFrame()
 
-    datalink_all = pd.concat(datalink_all)
+    # push objectid/label into the nested epoch_photometry frame so they attach to every
+    # flattened transit row, then flatten to one row per transit measurement.
+    matched_df["epoch_photometry.objectid"] = matched_df["objectid"]
+    matched_df["epoch_photometry.label"] = matched_df["label"]
+    gaia_df = matched_df["epoch_photometry"].nest.to_flat()
 
-    # join with gaia_table to attach the objectid and label
-    idcols = ["source_id", "objectid", "label"]
-    gaia_source_df = gaia_table[idcols].to_pandas().set_index("source_id")
-    gaia_df = datalink_all.set_index("source_id").join(gaia_source_df, how="left")
+    # the nested arrays can arrive as object dtype; coerce the columns we use to float and drop
+    # transits with no valid flux (masked/NaN measurements).
+    arr_cols = ['g_transit_flux', 'g_transit_flux_error', 'g_transit_mag', 'g_transit_time']
+    for col in arr_cols:
+        gaia_df[col] = pd.to_numeric(gaia_df[col], errors="coerce").astype(np.float64)
+    gaia_df = gaia_df.dropna(subset=['g_transit_flux'])
 
-    return gaia_df.reset_index()
+    return gaia_df.reset_index(drop=True)
 
 
 # clean and transform the data
@@ -312,7 +202,7 @@ def gaia_clean_dataframe(gaia_df):
     Returns
     --------
     df_lc : MultiIndexDFObject
-        Indexed by [objectid, label, band, time].  
+        Indexed by [objectid, label, band, time].
         The resulting internal pandas DataFrame contains:
 
             flux : float

--- a/light_curves/code_src/gaia_functions.py
+++ b/light_curves/code_src/gaia_functions.py
@@ -121,7 +121,9 @@ def gaia_retrieve_epoch_photometry(sample_table, search_radius, verbose):
     # `epoch_photometry`); ra/dec are used implicitly for the positional cross-match.
     epoch_catalog = lsdb.open_catalog(
         GAIA_EPOCH_PHOT_HATS,
-        columns=["ra", "dec", "source_id", "epoch_photometry"],
+        columns=["ra", "dec", "source_id",
+                 "epoch_photometry.g_transit_flux", "epoch_photometry.g_transit_flux_error",
+                 "epoch_photometry.g_transit_mag", "epoch_photometry.g_transit_time"],
     )
 
     # convert our sample's coordinates into an LSDB catalog for cross-matching
@@ -167,11 +169,11 @@ def gaia_retrieve_epoch_photometry(sample_table, search_radius, verbose):
     matched_df["epoch_photometry.label"] = matched_df["label"]
     gaia_df = matched_df["epoch_photometry"].nest.to_flat()
 
-    # the nested arrays can arrive as object dtype; coerce the columns we use to float and drop
-    # transits with no valid flux (masked/NaN measurements).
+    # the flattened columns are pyarrow-backed; convert the ones we use to numpy floats
+    # (like the other archives) so downstream plotting works, then drop transits with no
+    # valid flux (masked/NaN measurements).
     arr_cols = ['g_transit_flux', 'g_transit_flux_error', 'g_transit_mag', 'g_transit_time']
-    for col in arr_cols:
-        gaia_df[col] = pd.to_numeric(gaia_df[col], errors="coerce").astype(np.float64)
+    gaia_df = gaia_df.astype({col: 'float64' for col in arr_cols})
     gaia_df = gaia_df.dropna(subset=['g_transit_flux'])
 
     return gaia_df.reset_index(drop=True)

--- a/light_curves/light_curve_collector.md
+++ b/light_curves/light_curve_collector.md
@@ -113,7 +113,6 @@ from wise_functions import wise_get_lightcurves
 from rubin_functions import rubin_get_lightcurves
 from ztf_functions import ztf_get_lightcurves
 
-# You may see a warning about passwords for the Gaia Archive.  This can safely be ignored.
 # You may see a warning about "tpfmodel submodule".  This can safely be ignored.
 ```
 
@@ -348,7 +347,7 @@ print('ZTF search took:', time.time() - ZTFstarttime, 's')
 
 ### 3.2 Gaia
 
-The function to retrieve Gaia light curves works in two steps. First it cross-matches our sample against the Gaia DR3 `gaia_source` catalog, accessed as a HATS catalog on AWS S3 using LSDB (the same cloud-native, scalable approach used for the ZTF and Pan-STARRS light curves), to look up the Gaia `source_id` of each target and keep only those with epoch photometry available. It then retrieves the epoch photometry for those sources from the Gaia DataLink service.
+The function to retrieve Gaia light curves cross-matches our sample against the Gaia DR3 epoch-photometry catalog, accessed as a HATS catalog using LSDB (the same cloud-native, scalable approach used for the ZTF and Pan-STARRS light curves). This catalog contains only the sources that have epoch photometry, with the light curves stored in a nested column, so a single positional cross-match returns the light curves directly.
 
 ```{code-cell} ipython3
 gaiastarttime = time.time()
@@ -508,7 +507,7 @@ These plots are modelled after [van Velzen et al., 2021](https://arxiv.org/abs/2
 __Note__ that in the following, we can either plot the results from `df_lc` (from the serial call) or `parallel_df_lc` (from the parallel call). By default (see next cell) the output of the parallel call is used.
 
 ```{code-cell} ipython3
-_ = create_figures(df_lc = parallel_df_lc, # either df_lc (serial call) or parallel_df_lc (parallel call)
+_ = create_figures(df_lc = df_lc, # either df_lc (serial call) or parallel_df_lc (parallel call)
                    show_nbr_figures = 5,  # how many plots do you actually want to see?
                    save_output = False ,  # should the resulting plots be saved?
                   )

--- a/light_curves/light_curve_collector.md
+++ b/light_curves/light_curve_collector.md
@@ -58,7 +58,7 @@ By the end of this tutorial, you will be able to:
 
 ### Runtime
 
-- As of 2025 May, this notebook takes ~1000s (17 min.) to run to completion on Fornax using a server with 64GB RAM/ 16CPU.
+- As of 2026 July, this notebook takes ~1000s (17 min.) to run to completion on Fornax using a server with 64GB RAM/ 16CPU.
 
 ## Imports
 
@@ -83,7 +83,7 @@ This cell will install them if needed:
 
 ```{code-cell} ipython3
 # Uncomment the next line to install dependencies if needed.
-# %pip install -r requirements_light_curve_collector.txt
+%pip install -r requirements_light_curve_collector.txt
 ```
 
 ```{code-cell} ipython3
@@ -115,6 +115,10 @@ from ztf_functions import ztf_get_lightcurves
 
 # You may see a warning about passwords for the Gaia Archive.  This can safely be ignored.
 # You may see a warning about "tpfmodel submodule".  This can safely be ignored.
+```
+
+```{code-cell} ipython3
+starttime = time.time()
 ```
 
 ## 1. Define the sample
@@ -529,3 +533,11 @@ This work made use of:
 * Lightkurve; Lightkurve Collaboration 2018, 2018ascl.soft12013L
 * acstools; https://zenodo.org/record/7406933#.ZBH1HS-B0eY
 * unWISE light curves; Meisner et al., 2023, 2023AJ....165...36M
+
+```{code-cell} ipython3
+print("total duration", (time.time() - starttime)/60.)
+```
+
+```{code-cell} ipython3
+
+```

--- a/light_curves/light_curve_collector.md
+++ b/light_curves/light_curve_collector.md
@@ -83,7 +83,7 @@ This cell will install them if needed:
 
 ```{code-cell} ipython3
 # Uncomment the next line to install dependencies if needed.
-%pip install -r requirements_light_curve_collector.txt
+#%pip install -r requirements_light_curve_collector.txt
 ```
 
 ```{code-cell} ipython3
@@ -114,10 +114,6 @@ from rubin_functions import rubin_get_lightcurves
 from ztf_functions import ztf_get_lightcurves
 
 # You may see a warning about "tpfmodel submodule".  This can safely be ignored.
-```
-
-```{code-cell} ipython3
-starttime = time.time()
 ```
 
 ## 1. Define the sample
@@ -532,11 +528,3 @@ This work made use of:
 * Lightkurve; Lightkurve Collaboration 2018, 2018ascl.soft12013L
 * acstools; https://zenodo.org/record/7406933#.ZBH1HS-B0eY
 * unWISE light curves; Meisner et al., 2023, 2023AJ....165...36M
-
-```{code-cell} ipython3
-print("total duration", (time.time() - starttime)/60.)
-```
-
-```{code-cell} ipython3
-
-```

--- a/light_curves/light_curve_collector.md
+++ b/light_curves/light_curve_collector.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.19.0
+    jupytext_version: 1.19.4
 kernelspec:
   display_name: py-light_curve_collector
   language: python
@@ -344,7 +344,7 @@ print('ZTF search took:', time.time() - ZTFstarttime, 's')
 
 ### 3.2 Gaia
 
-The function to retrieve Gaia light curves accesses the Gaia DR3 "source lite" catalog using an astroquery search with a table upload to do the join with the Gaia photometry. This is currently the fastest way to access light curves from Gaia at scale.
+The function to retrieve Gaia light curves works in two steps. First it cross-matches our sample against the Gaia DR3 `gaia_source` catalog, accessed as a HATS catalog on AWS S3 using LSDB (the same cloud-native, scalable approach used for the ZTF and Pan-STARRS light curves), to look up the Gaia `source_id` of each target and keep only those with epoch photometry available. It then retrieves the epoch photometry for those sources from the Gaia DataLink service.
 
 ```{code-cell} ipython3
 gaiastarttime = time.time()
@@ -419,8 +419,9 @@ For sample sizes >~500 and/or improved logging and monitoring options, consider 
 
 ```{code-cell} ipython3
 # number of workers to use in the parallel processing pool
-# this should equal the total number of archives called
-n_workers = 6
+# this should equal the total number of archives called in the pool below
+# (Gaia, ZTF, and Pan-STARRS are run outside the pool, see below)
+n_workers = 5
 
 # keyword arguments for the archive calls
 heasarc_kwargs = dict(catalog_error_radii={"FERMIGTRIG": "1.0", "SAXGRBMGRB": "3.0"})
@@ -448,16 +449,18 @@ with mp.Pool(processes=n_workers) as pool:
     pool.apply_async(wise_get_lightcurves, args=(sample_table,), kwds=wise_kwargs, callback=callback)
     pool.apply_async(tess_kepler_get_lightcurves, args=(sample_table,), kwds=tess_kepler_kwargs, callback=callback)
     pool.apply_async(hcv_get_lightcurves, args=(sample_table,), kwds=hcv_kwargs, callback=callback)
-    pool.apply_async(gaia_get_lightcurves, args=(sample_table,), kwds=gaia_kwargs, callback=callback)
     pool.apply_async(icecube_get_lightcurves, args=(sample_table,), kwds=icecube_kwargs, callback=callback)
 #    pool.apply_async(rubin_get_lightcurves, args=(sample_table,), kwds=rsp_kwargs, callback=callback)
 
     pool.close()  # signal that no more jobs will be submitted to the pool
     pool.join()  # wait for all jobs to complete, including the callback
 
-# run ZTF and panstarrs queries outside of multiprocessing since they
+# run Gaia, ZTF, and panstarrs queries outside of multiprocessing since they
 # are using dask distributed under the hood,
 # which doesn't work with multiprocessing, and dask is already parallelized
+
+df_lc_gaia = gaia_get_lightcurves(sample_table, **gaia_kwargs)
+parallel_df_lc.append(df_lc_gaia)# add the resulting dataframe to all other archives
 
 df_lc_ZTF = ztf_get_lightcurves(sample_table, radius = ztf_search_radius)
 parallel_df_lc.append(df_lc_ZTF)# add the resulting dataframe to all other archives

--- a/light_curves/light_curve_collector.md
+++ b/light_curves/light_curve_collector.md
@@ -343,7 +343,7 @@ print('ZTF search took:', time.time() - ZTFstarttime, 's')
 
 ### 3.2 Gaia
 
-The function to retrieve Gaia light curves cross-matches our sample against the Gaia DR3 epoch-photometry catalog, accessed as a HATS catalog using LSDB (the same cloud-native, scalable approach used for the ZTF and Pan-STARRS light curves). This catalog contains only the sources that have epoch photometry, with the light curves stored in a nested column, so a single positional cross-match returns the light curves directly.
+The function to retrieve Gaia light curves cross-matches our sample against the Gaia DR3 epoch-photometry catalog, accessed as a HATS catalog using LSDB (the same cloud-native, scalable approach used for the ZTF and Pan-STARRS light curves).
 
 ```{code-cell} ipython3
 gaiastarttime = time.time()

--- a/light_curves/scale_up.md
+++ b/light_curves/scale_up.md
@@ -410,7 +410,7 @@ different way, so that the calls are also allowed to parallelize their own inter
 
 ```{code-cell}
 # Skip archive calls that use internal parallelization.
-_archive_names = [name for name in archive_names if name.lower() not in ["panstarrs", "ztf"]]
+_archive_names = [name for name in archive_names if name.lower() not in ["gaia", "panstarrs", "ztf"]]
 
 sample_table = helpers.scale_up.run(build="sample", **kwargs_dict)
 # sample_table is returned if you want to look at it but it is not used below


### PR DESCRIPTION
closes #610 

Replaces the Gaia light curve lookup with a cross-match against the Gaia DR3 HATS catalog using LSDB.  This was done using existing ZTF and panstarrs code as a template. In the multiprocessing section, Gaia now runs outside the pool, along with the other LSDB based database queries, since dask and multiprocessing don't mix well.  

Updates the runtime notes in light_curve_collector accordingly, no real change in time for this sample size.  