### PR TITLE
Bugfix blank suffixes

### DIFF
--- a/light_curves/code_src/panstarrs_functions.py
+++ b/light_curves/code_src/panstarrs_functions.py
@@ -66,7 +66,7 @@ def panstarrs_get_lightcurves(sample_table, *, radius=1):
         panstarrs_object,
         radius_arcsec=radius,
         n_neighbors=1,
-        suffixes=("", ""),
+        suffixes=("_sample", "_panstarrs"),
         suffix_method="overlapping_columns",
         log_changes=False,
     )
@@ -91,7 +91,7 @@ def panstarrs_get_lightcurves(sample_table, *, radius=1):
         left_on="objID",
         right_on="objID",
         output_catalog_name="yang_ps_lc",
-        suffixes=["", ""],
+        suffixes=["_matched", "_panstarrs"],
         suffix_method="overlapping_columns",
         log_changes=False,
     )


### PR DESCRIPTION
closes #710 

Fixes a bug in the panstarrs lsdb calls where the suffixes to rename overlapping columns were set to `suffixes=["", ""]`, which doesn't produce unique names for overlapping columns.

I expect tests to fail due to #697 and/or #700.